### PR TITLE
Ignore extra semicolons between statements

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -104,7 +104,7 @@ export function parse(input: string, isStrict = true, dialect: Dialect = 'generi
     state: topLevelState,
   };
 
-  const ignoreOutsideBlankTokens = ['whitespace', 'comment-inline', 'comment-block'];
+  const ignoreOutsideBlankTokens = ['whitespace', 'comment-inline', 'comment-block', 'semicolon'];
 
   while (prevState.position < topLevelState.end) {
     const tokenState = initState({ prevState });

--- a/test/identifier/multiple-statement.spec.ts
+++ b/test/identifier/multiple-statement.spec.ts
@@ -132,5 +132,43 @@ describe('identifier', () => {
 
       expect(actual).to.eql(expected);
     });
+
+    it('should able to ignore empty statements (extra semicolons)', () => {
+      const actual = identify(
+        `
+        ;select 1;;select 2;;;
+        ;
+        select 3;
+      `,
+      );
+      const expected = [
+        {
+          start: 10,
+          end: 18,
+          text: 'select 1;',
+          type: 'SELECT',
+          executionType: 'LISTING',
+          parameters: [],
+        },
+        {
+          start: 20,
+          end: 28,
+          text: 'select 2;',
+          type: 'SELECT',
+          executionType: 'LISTING',
+          parameters: [],
+        },
+        {
+          start: 50,
+          end: 58,
+          text: 'select 3;',
+          type: 'SELECT',
+          executionType: 'LISTING',
+          parameters: [],
+        },
+      ];
+
+      expect(actual).to.eql(expected);
+    });
   });
 });


### PR DESCRIPTION
I'm not sure whether you'd prefer to have this controlled by the `strict` flag, or possibly a new flag. I believe that most (if not all) SQL interpreters will ignore empty statements (extra semicolons), so it seems reasonable that this parser/identifier should do the same.
