### PR TITLE
Fix parsing trailing non-alphanumerics in mssql parameters

### DIFF
--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -283,9 +283,7 @@ function scanParameter(state: State, dialect: Dialect): Token {
   }
 
   if (dialect === 'mssql') {
-    while(isAlphaNumeric(peek(state))) {
-      read(state);
-    }
+    while(isAlphaNumeric(peek(state))) read(state);
 
     const value = state.input.slice(state.start, state.position + 1);
     return {
@@ -407,7 +405,7 @@ function isWhitespace(ch: Char): boolean {
 }
 
 function isAlphaNumeric(ch: Char): boolean {
-  return ch !== null && /[a-zA-Z0-9_]/.test(ch);
+  return ch !== null && /\w/.test(ch);
 }
 
 function isString(ch: Char, dialect: Dialect): boolean {

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -283,12 +283,9 @@ function scanParameter(state: State, dialect: Dialect): Token {
   }
 
   if (dialect === 'mssql') {
-    let nextChar: Char;
-    do {
-      nextChar = read(state);
-    } while (!isWhitespace(nextChar) && nextChar !== null);
-
-    if (isWhitespace(nextChar)) unread(state);
+    while(isAlphaNumeric(peek(state))) {
+      read(state);
+    }
 
     const value = state.input.slice(state.start, state.position + 1);
     return {
@@ -407,6 +404,10 @@ function skipWord(state: State, value: string): Token {
 
 function isWhitespace(ch: Char): boolean {
   return ch === ' ' || ch === '\t' || ch === '\n' || ch === '\r';
+}
+
+function isAlphaNumeric(ch: Char): boolean {
+  return ch !== null && /[a-zA-Z0-9_]/.test(ch);
 }
 
 function isString(ch: Char, dialect: Dialect): boolean {

--- a/test/identifier/single-statement.spec.ts
+++ b/test/identifier/single-statement.spec.ts
@@ -1368,18 +1368,18 @@ describe('identifier', () => {
     });
 
     it('Should extract positional Parameters with trailing commas', () => {
-      const actual = identify('SELECT $1,$2 FROM foo', {
+      const actual = identify('SELECT $1,$2 FROM foo WHERE foo.id in ($3, $4)', {
         dialect: 'psql',
         strict: true,
       });
       const expected = [
         {
           start: 0,
-          end: 20,
-          text: 'SELECT $1,$2 FROM foo',
+          end: 45,
+          text: 'SELECT $1,$2 FROM foo WHERE foo.id in ($3, $4)',
           type: 'SELECT',
           executionType: 'LISTING',
-          parameters: ['$1', '$2'],
+          parameters: ['$1', '$2', '$3', '$4'],
         },
       ];
 
@@ -1399,6 +1399,25 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [':one', ':two'],
+        },
+      ];
+
+      expect(actual).to.eql(expected);
+    });
+
+    it('Should extract named Parameters with trailing commas', () => {
+      const actual = identify('SELECT * FROM Persons where x in (:one, :two, :three)', {
+        dialect: 'mssql',
+        strict: true,
+      });
+      const expected = [
+        {
+          start: 0,
+          end: 52,
+          text: 'SELECT * FROM Persons where x in (:one, :two, :three)',
+          type: 'SELECT',
+          executionType: 'LISTING',
+          parameters: [':one', ':two', ':three'],
         },
       ];
 

--- a/test/tokenizer/index.spec.ts
+++ b/test/tokenizer/index.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { scanToken } from '../../src/tokenizer';
 import type { Dialect } from '../../src/defines';
+import { parse } from '../../src/parser';
 
 describe('scan', () => {
   const initState = (input: string) => ({
@@ -352,6 +353,29 @@ describe('scan', () => {
           end: 1,
         };
         expect(actual).to.eql(expected);
+      });
+
+      it('should not include trailing non-alphanumerics for mssql', () => {
+        [
+          {
+            actual: scanToken(initState(':one,'), 'mssql'),
+            expected: {
+              type: 'parameter',
+              value: ':one',
+              start: 0,
+              end: 3,
+            },
+          },
+          {
+            actual: scanToken(initState(':two)'), 'mssql'),
+            expected: {
+              type: 'parameter',
+              value: ':two',
+              start: 0,
+              end: 3,
+            },
+          },
+        ].forEach(({ actual, expected }) => expect(actual).to.eql(expected));
       });
     });
   });


### PR DESCRIPTION
This is an attempt to improve tokenizing parameters in mssql where there are trailing non-alphanumerics like:

```sql
SELECT * FROM Persons WHERE id IN (:foo, :bar);
```

This should parse `:foo` and `:bar` instead of `:foo,` and `:bar);`.