### PR TITLE
Run CI against Node 18,20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x, 17.x]
+        node-version: [10.x, 12.x, 14.x, 16.x, 18.x, 20.x]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
PR updates the versions of node that the library tests against, dropping Node 17.x as it's not supported nor a LTS, adding 18.x and 20.x in its place.