### PR TITLE
Add initial support for table identification

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,12 +34,11 @@
     "prettier": "^2.3.2",
     "terser-webpack-plugin": "^5.1.1",
     "ts-loader": "^8.0.17",
-    "ts-node": "^9.1.1",
+    "ts-node": "^10.9.2",
     "typescript": "^4.1.5",
     "webpack": "^5.11.1",
     "webpack-cli": "^4.3.1"
   },
-  "dependencies": {},
   "engines": {
     "node": ">= 10.13"
   }

--- a/src/defines.ts
+++ b/src/defines.ts
@@ -103,6 +103,7 @@ export interface Statement {
   sqlSecurity?: number;
   parameters: string[];
   tables: string[];
+  isCte?: boolean;
 }
 
 export interface ConcreteStatement extends Statement {

--- a/src/defines.ts
+++ b/src/defines.ts
@@ -79,6 +79,7 @@ export type ExecutionType = 'LISTING' | 'MODIFICATION' | 'INFORMATION' | 'ANON_B
 export interface IdentifyOptions {
   strict?: boolean;
   dialect?: Dialect;
+  identifyTables?: boolean;
 }
 
 export interface IdentifyResult {
@@ -88,7 +89,7 @@ export interface IdentifyResult {
   type: StatementType;
   executionType: ExecutionType;
   parameters: string[];
-  tables?: string[];
+  tables: string[];
 }
 
 export interface Statement {

--- a/src/defines.ts
+++ b/src/defines.ts
@@ -88,6 +88,7 @@ export interface IdentifyResult {
   type: StatementType;
   executionType: ExecutionType;
   parameters: string[];
+  tables?: string[]
 }
 
 export interface Statement {
@@ -101,6 +102,7 @@ export interface Statement {
   algorithm?: number;
   sqlSecurity?: number;
   parameters: string[];
+  tables: string[];
 }
 
 export interface ConcreteStatement extends Statement {
@@ -124,6 +126,7 @@ export interface Token {
     | 'semicolon'
     | 'keyword'
     | 'parameter'
+    | 'table'
     | 'unknown';
   value: string;
   start: number;

--- a/src/defines.ts
+++ b/src/defines.ts
@@ -88,7 +88,7 @@ export interface IdentifyResult {
   type: StatementType;
   executionType: ExecutionType;
   parameters: string[];
-  tables?: string[]
+  tables?: string[];
 }
 
 export interface Statement {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ export function identify(query: string, options: IdentifyOptions = {}): Identify
     throw new Error(`Unknown dialect. Allowed values: ${DIALECTS.join(', ')}`);
   }
 
-  const result = parse(query, isStrict, dialect);
+  const result = parse(query, isStrict, dialect, options.identifyTables);
 
   return result.body.map((statement) => {
     const result: IdentifyResult = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ export function identify(query: string, options: IdentifyOptions = {}): Identify
       executionType: statement.executionType,
       // we want to sort the postgres params: $1 $2 $3, regardless of the order they appear
       parameters: dialect === 'psql' ? statement.parameters.sort() : statement.parameters,
+      tables: statement.tables || [],
     };
     return result;
   });

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -98,10 +98,9 @@ const statementsWithEnds = [
   'UNKNOWN',
 ];
 
-
 // keywords that come directly before a table name.
 // v1 - keeping it very simple.
-const PRE_TABLE_KEYWORDS = /from|join|into/i
+const PRE_TABLE_KEYWORDS = /from|join|into/i;
 
 const blockOpeners: Record<Dialect, string[]> = {
   generic: ['BEGIN', 'CASE'],
@@ -123,11 +122,11 @@ function createInitialStatement(): Statement {
     start: -1,
     end: 0,
     parameters: [],
-    tables: []
+    tables: [],
   };
 }
 
-function nextNonWhitespaceToken(state: State, dialect: Dialect = "generic"): Token {
+function nextNonWhitespaceToken(state: State, dialect: Dialect = 'generic'): Token {
   let token: Token;
   do {
     state = initState({ prevState: state });
@@ -177,7 +176,6 @@ export function parse(input: string, isStrict = true, dialect: Dialect = 'generi
       if (!cteState.isCte && ignoreOutsideBlankTokens.includes(token.type)) {
         topLevelStatement.tokens.push(token);
         prevState = tokenState;
-
       } else if (
         !cteState.isCte &&
         token.type === 'keyword' &&
@@ -199,13 +197,12 @@ export function parse(input: string, isStrict = true, dialect: Dialect = 'generi
           type: 'UNKNOWN',
           executionType: 'UNKNOWN',
           parameters: [],
-          tables: []
+          tables: [],
         });
         cteState.isCte = false;
         cteState.asSeen = false;
         cteState.statementEnd = false;
         cteState.parens = 0;
-
       } else if (cteState.isCte && !cteState.statementEnd) {
         if (cteState.asSeen) {
           if (token.value === '(') {
@@ -222,7 +219,6 @@ export function parse(input: string, isStrict = true, dialect: Dialect = 'generi
 
         topLevelStatement.tokens.push(token);
         prevState = tokenState;
-
       } else if (cteState.isCte && cteState.statementEnd && token.value === ',') {
         cteState.asSeen = false;
         cteState.statementEnd = false;
@@ -238,7 +234,6 @@ export function parse(input: string, isStrict = true, dialect: Dialect = 'generi
       ) {
         topLevelStatement.tokens.push(token);
         prevState = tokenState;
-
       } else {
         statementParser = createStatementParserByToken(token, nextToken, { isStrict, dialect });
         if (cteState.isCte) {
@@ -248,7 +243,6 @@ export function parse(input: string, isStrict = true, dialect: Dialect = 'generi
           cteState.asSeen = false;
           cteState.statementEnd = false;
         }
-
       }
     } else {
       statementParser.addToken(token, nextToken);
@@ -262,7 +256,6 @@ export function parse(input: string, isStrict = true, dialect: Dialect = 'generi
         statementParser = null;
       }
     }
-
   }
 
   // last statement without ending key
@@ -820,11 +813,13 @@ function stateMachineStatementParser(
 
       if (
         // TODO: tokenize this?
-        token.value.match(PRE_TABLE_KEYWORDS) && !statement.isCte && statement.type?.match(/SELECT|INSERT/)
+        PRE_TABLE_KEYWORDS.exec(token.value) &&
+        !statement.isCte &&
+        statement.type?.match(/SELECT|INSERT/)
       ) {
-        const tableValue = nextToken.value
+        const tableValue = nextToken.value;
         if (!statement.tables.includes(tableValue)) {
-          statement.tables.push(tableValue)
+          statement.tables.push(tableValue);
         }
       }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -820,7 +820,7 @@ function stateMachineStatementParser(
 
       if (
         // TODO: tokenize this?
-        token.value.match(PRE_TABLE_KEYWORDS) && !statement.isCte && statement.type === 'SELECT'
+        token.value.match(PRE_TABLE_KEYWORDS) && !statement.isCte && statement.type?.match(/SELECT|INSERT/)
       ) {
         const tableValue = nextToken.value
         if (!statement.tables.includes(tableValue)) {

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -65,6 +65,7 @@ const KEYWORDS = [
   'WARNINGS',
 ];
 
+
 const INDIVIDUALS: Record<string, Token['type']> = {
   ';': 'semicolon',
 };
@@ -253,6 +254,7 @@ function scanString(state: State, endToken: Char): Token {
   };
 }
 
+
 function scanParameter(state: State, dialect: Dialect): Token {
   if (['mysql', 'generic', 'sqlite'].includes(dialect)) {
     return {
@@ -413,6 +415,7 @@ function isString(ch: Char, dialect: Dialect): boolean {
   const stringStart: Char[] = dialect === 'mysql' ? ["'", '"'] : ["'"];
   return stringStart.includes(ch);
 }
+
 
 function isParameter(ch: Char, state: State, dialect: Dialect): boolean {
   let pStart = '?'; // ansi standard - sqlite, mysql

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -65,7 +65,6 @@ const KEYWORDS = [
   'WARNINGS',
 ];
 
-
 const INDIVIDUALS: Record<string, Token['type']> = {
   ';': 'semicolon',
 };
@@ -254,7 +253,6 @@ function scanString(state: State, endToken: Char): Token {
   };
 }
 
-
 function scanParameter(state: State, dialect: Dialect): Token {
   if (['mysql', 'generic', 'sqlite'].includes(dialect)) {
     return {
@@ -415,7 +413,6 @@ function isString(ch: Char, dialect: Dialect): boolean {
   const stringStart: Char[] = dialect === 'mysql' ? ["'", '"'] : ["'"];
   return stringStart.includes(ch);
 }
-
 
 function isParameter(ch: Char, state: State, dialect: Dialect): boolean {
   let pStart = '?'; // ansi standard - sqlite, mysql

--- a/test/identifier/inner-statements.spec.ts
+++ b/test/identifier/inner-statements.spec.ts
@@ -16,7 +16,7 @@ describe('identifier', () => {
           type: 'INSERT',
           executionType: 'MODIFICATION',
           parameters: [],
-          tables: [],
+          tables: ['Customers', 'Suppliers'],
         },
       ];
 
@@ -35,7 +35,7 @@ describe('identifier', () => {
           type: 'INSERT',
           executionType: 'MODIFICATION',
           parameters: [],
-          tables: [],
+          tables: ['Customers', 'Suppliers'],
         },
       ];
 
@@ -56,7 +56,7 @@ describe('identifier', () => {
           type: 'INSERT',
           executionType: 'MODIFICATION',
           parameters: [],
-          tables: [],
+          tables: ['Customers', 'Suppliers'],
         },
       ];
 
@@ -78,7 +78,7 @@ describe('identifier', () => {
           type: 'INSERT',
           executionType: 'MODIFICATION',
           parameters: [],
-          tables: [],
+          tables: ['Customers', 'Suppliers'],
         },
       ];
 

--- a/test/identifier/inner-statements.spec.ts
+++ b/test/identifier/inner-statements.spec.ts
@@ -16,6 +16,7 @@ describe('identifier', () => {
           type: 'INSERT',
           executionType: 'MODIFICATION',
           parameters: [],
+          tables: ['customers', 'suppliers']
         },
       ];
 
@@ -34,6 +35,7 @@ describe('identifier', () => {
           type: 'INSERT',
           executionType: 'MODIFICATION',
           parameters: [],
+          tables: ['customers', 'suppliers']
         },
       ];
 
@@ -54,6 +56,7 @@ describe('identifier', () => {
           type: 'INSERT',
           executionType: 'MODIFICATION',
           parameters: [],
+          tables: ['customers', 'suppliers']
         },
       ];
 
@@ -75,6 +78,7 @@ describe('identifier', () => {
           type: 'INSERT',
           executionType: 'MODIFICATION',
           parameters: [],
+          tables: ['customers', 'suppliers']
         },
       ];
 

--- a/test/identifier/inner-statements.spec.ts
+++ b/test/identifier/inner-statements.spec.ts
@@ -16,7 +16,7 @@ describe('identifier', () => {
           type: 'INSERT',
           executionType: 'MODIFICATION',
           parameters: [],
-          tables: ['Customers', 'Suppliers'],
+          tables: [],
         },
       ];
 
@@ -35,7 +35,7 @@ describe('identifier', () => {
           type: 'INSERT',
           executionType: 'MODIFICATION',
           parameters: [],
-          tables: ['Customers', 'Suppliers'],
+          tables: [],
         },
       ];
 
@@ -56,7 +56,7 @@ describe('identifier', () => {
           type: 'INSERT',
           executionType: 'MODIFICATION',
           parameters: [],
-          tables: ['Customers', 'Suppliers'],
+          tables: [],
         },
       ];
 
@@ -78,7 +78,7 @@ describe('identifier', () => {
           type: 'INSERT',
           executionType: 'MODIFICATION',
           parameters: [],
-          tables: ['Customers', 'Suppliers'],
+          tables: [],
         },
       ];
 

--- a/test/identifier/inner-statements.spec.ts
+++ b/test/identifier/inner-statements.spec.ts
@@ -16,7 +16,7 @@ describe('identifier', () => {
           type: 'INSERT',
           executionType: 'MODIFICATION',
           parameters: [],
-          tables: ['customers', 'suppliers']
+          tables: [],
         },
       ];
 
@@ -35,7 +35,7 @@ describe('identifier', () => {
           type: 'INSERT',
           executionType: 'MODIFICATION',
           parameters: [],
-          tables: ['customers', 'suppliers']
+          tables: [],
         },
       ];
 
@@ -56,7 +56,7 @@ describe('identifier', () => {
           type: 'INSERT',
           executionType: 'MODIFICATION',
           parameters: [],
-          tables: ['customers', 'suppliers']
+          tables: [],
         },
       ];
 
@@ -78,7 +78,7 @@ describe('identifier', () => {
           type: 'INSERT',
           executionType: 'MODIFICATION',
           parameters: [],
-          tables: ['customers', 'suppliers']
+          tables: [],
         },
       ];
 

--- a/test/identifier/multiple-statement.spec.ts
+++ b/test/identifier/multiple-statement.spec.ts
@@ -16,7 +16,7 @@ describe('identifier', () => {
           type: 'INSERT',
           executionType: 'MODIFICATION',
           parameters: [],
-          tables: ['persons'],
+          tables: [],
         },
         {
           end: 76,
@@ -25,7 +25,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [],
-          tables: ['persons']
+          tables: ['Persons']
         },
       ];
 
@@ -46,6 +46,7 @@ describe('identifier', () => {
           type: 'INSERT',
           executionType: 'MODIFICATION',
           parameters: [],
+          tables: [],
         },
         {
           start: 74,
@@ -54,6 +55,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [],
+          tables: ['Persons']
         },
       ];
 
@@ -77,6 +79,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [],
+          tables: [],
         },
         {
           start: 35,
@@ -85,6 +88,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [],
+          tables: ['table'],
         },
       ];
 
@@ -107,6 +111,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [],
+          tables: [],
         },
         {
           start: 20,
@@ -115,6 +120,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [],
+          tables: [],
         },
         {
           start: 50,
@@ -123,6 +129,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [],
+          tables: [],
         },
       ];
 
@@ -163,6 +170,7 @@ describe('identifier', () => {
             end: 1043,
             executionType: 'ANON_BLOCK',
             parameters: [],
+            tables: [],
             start: 11,
             text: 'DECLARE\n            PK_NAME VARCHAR(200);\n\n          BEGIN\n            EXECUTE IMMEDIATE (\'CREATE SEQUENCE "untitled_table8_seq"\');\n\n          SELECT\n            cols.column_name INTO PK_NAME\n          FROM\n            all_constraints cons,\n            all_cons_columns cols\n          WHERE\n            cons.constraint_type = \'P\'\n            AND cons.constraint_name = cols.constraint_name\n            AND cons.owner = cols.owner\n            AND cols.table_name = \'untitled_table8\';\n\n          execute immediate (\n            \'create or replace trigger "untitled_table8_autoinc_trg"  BEFORE INSERT on "untitled_table8"  for each row  declare  checking number := 1;  begin    if (:new."\' || PK_NAME || \'" is null) then      while checking >= 1 loop        select "untitled_table8_seq".nextval into :new."\' || PK_NAME || \'" from dual;        select count("\' || PK_NAME || \'") into checking from "untitled_table8"        where "\' || PK_NAME || \'" = :new."\' || PK_NAME || \'";      end loop;    end if;  end;\'\n          );\n\n          END;',
             type: 'ANON_BLOCK',
@@ -210,6 +218,7 @@ describe('identifier', () => {
             end: 167,
             executionType: 'MODIFICATION',
             parameters: [],
+            tables: [],
             start: 11,
             text: 'create table\n            "untitled_table8" (\n              "id" integer not null primary key,\n              "created_at" varchar(255) not null\n            );',
             type: 'CREATE_TABLE',
@@ -218,6 +227,7 @@ describe('identifier', () => {
             end: 1212,
             executionType: 'ANON_BLOCK',
             parameters: [],
+            tables: [],
             start: 180,
             text: 'DECLARE\n            PK_NAME VARCHAR(200);\n\n          BEGIN\n            EXECUTE IMMEDIATE (\'CREATE SEQUENCE "untitled_table8_seq"\');\n\n          SELECT\n            cols.column_name INTO PK_NAME\n          FROM\n            all_constraints cons,\n            all_cons_columns cols\n          WHERE\n            cons.constraint_type = \'P\'\n            AND cons.constraint_name = cols.constraint_name\n            AND cons.owner = cols.owner\n            AND cols.table_name = \'untitled_table8\';\n\n          execute immediate (\n            \'create or replace trigger "untitled_table8_autoinc_trg"  BEFORE INSERT on "untitled_table8"  for each row  declare  checking number := 1;  begin    if (:new."\' || PK_NAME || \'" is null) then      while checking >= 1 loop        select "untitled_table8_seq".nextval into :new."\' || PK_NAME || \'" from dual;        select count("\' || PK_NAME || \'") into checking from "untitled_table8"        where "\' || PK_NAME || \'" = :new."\' || PK_NAME || \'";      end loop;    end if;  end;\'\n          );\n\n          END;',
             type: 'ANON_BLOCK',
@@ -250,6 +260,7 @@ describe('identifier', () => {
             type: 'INSERT',
             executionType: 'MODIFICATION',
             parameters: [],
+            tables: [],
           },
           {
             start: 79,
@@ -258,6 +269,7 @@ describe('identifier', () => {
             type: 'SELECT',
             executionType: 'LISTING',
             parameters: [],
+            tables: [],
           },
           {
             start: 250,
@@ -266,6 +278,7 @@ describe('identifier', () => {
             type: 'SELECT',
             executionType: 'LISTING',
             parameters: [],
+            tables: ['Persons'],
           },
         ];
 
@@ -288,6 +301,7 @@ describe('identifier', () => {
             type: 'UNKNOWN',
             executionType: 'UNKNOWN',
             parameters: [],
+            tables: [],
           },
           {
             start: 54,
@@ -296,6 +310,7 @@ describe('identifier', () => {
             type: 'SELECT',
             executionType: 'LISTING',
             parameters: [],
+            tables: ['foo'],
           },
         ];
 
@@ -319,6 +334,7 @@ describe('identifier', () => {
           type: 'UNKNOWN',
           executionType: 'UNKNOWN',
           parameters: [],
+          tables: [],
         },
         {
           start: 6,
@@ -327,6 +343,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [],
+          tables: ['foo'],
         },
       ];
 
@@ -349,6 +366,7 @@ describe('identifier', () => {
           type: 'UNKNOWN',
           executionType: 'UNKNOWN',
           parameters: [],
+          tables: [],
         },
         {
           start: 24,
@@ -357,6 +375,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [],
+          tables: ['foo'],
         },
       ];
 
@@ -378,6 +397,7 @@ describe('identifier', () => {
           type: 'UNKNOWN',
           executionType: 'UNKNOWN',
           parameters: [],
+          tables: [],
         },
         {
           start: 19,
@@ -386,6 +406,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [],
+          tables: [],
         },
         {
           start: 29,
@@ -394,6 +415,7 @@ describe('identifier', () => {
           type: 'UNKNOWN',
           executionType: 'UNKNOWN',
           parameters: [],
+          tables: [],
         },
       ];
       expect(actual).to.eql(expected);
@@ -413,6 +435,7 @@ describe('identifier', () => {
               type: 'UNKNOWN',
               executionType: 'UNKNOWN',
               parameters: [],
+              tables: [],
             },
             {
               start: 19 + offset,
@@ -421,6 +444,7 @@ describe('identifier', () => {
               type: 'SELECT',
               executionType: 'LISTING',
               parameters: [],
+              tables: [],
             },
             {
               start: 29 + offset,
@@ -429,6 +453,7 @@ describe('identifier', () => {
               type: 'UNKNOWN',
               executionType: 'UNKNOWN',
               parameters: [],
+              tables: [],
             },
           ];
           expect(actual).to.eql(expected);

--- a/test/identifier/multiple-statement.spec.ts
+++ b/test/identifier/multiple-statement.spec.ts
@@ -16,6 +16,7 @@ describe('identifier', () => {
           type: 'INSERT',
           executionType: 'MODIFICATION',
           parameters: [],
+          tables: ['persons'],
         },
         {
           end: 76,
@@ -24,6 +25,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [],
+          tables: ['persons']
         },
       ];
 

--- a/test/identifier/multiple-statement.spec.ts
+++ b/test/identifier/multiple-statement.spec.ts
@@ -25,7 +25,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [],
-          tables: ['Persons']
+          tables: ['Persons'],
         },
       ];
 
@@ -55,7 +55,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [],
-          tables: ['Persons']
+          tables: ['Persons'],
         },
       ];
 

--- a/test/identifier/multiple-statement.spec.ts
+++ b/test/identifier/multiple-statement.spec.ts
@@ -16,7 +16,7 @@ describe('identifier', () => {
           type: 'INSERT',
           executionType: 'MODIFICATION',
           parameters: [],
-          tables: ['Persons'],
+          tables: [],
         },
         {
           end: 76,
@@ -25,7 +25,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [],
-          tables: ['Persons'],
+          tables: [],
         },
       ];
 
@@ -46,7 +46,7 @@ describe('identifier', () => {
           type: 'INSERT',
           executionType: 'MODIFICATION',
           parameters: [],
-          tables: ['Persons'],
+          tables: [],
         },
         {
           start: 74,
@@ -55,7 +55,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [],
-          tables: ['Persons'],
+          tables: [],
         },
       ];
 
@@ -88,7 +88,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [],
-          tables: ['table'],
+          tables: [],
         },
       ];
 
@@ -260,7 +260,7 @@ describe('identifier', () => {
             type: 'INSERT',
             executionType: 'MODIFICATION',
             parameters: [],
-            tables: ['Persons'],
+            tables: [],
           },
           {
             start: 79,
@@ -278,7 +278,7 @@ describe('identifier', () => {
             type: 'SELECT',
             executionType: 'LISTING',
             parameters: [],
-            tables: ['Persons'],
+            tables: [],
           },
         ];
 
@@ -310,7 +310,7 @@ describe('identifier', () => {
             type: 'SELECT',
             executionType: 'LISTING',
             parameters: [],
-            tables: ['foo'],
+            tables: [],
           },
         ];
 
@@ -343,7 +343,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [],
-          tables: ['foo'],
+          tables: [],
         },
       ];
 
@@ -375,7 +375,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [],
-          tables: ['foo'],
+          tables: [],
         },
       ];
 

--- a/test/identifier/multiple-statement.spec.ts
+++ b/test/identifier/multiple-statement.spec.ts
@@ -16,7 +16,7 @@ describe('identifier', () => {
           type: 'INSERT',
           executionType: 'MODIFICATION',
           parameters: [],
-          tables: [],
+          tables: ['Persons'],
         },
         {
           end: 76,
@@ -46,7 +46,7 @@ describe('identifier', () => {
           type: 'INSERT',
           executionType: 'MODIFICATION',
           parameters: [],
-          tables: [],
+          tables: ['Persons'],
         },
         {
           start: 74,
@@ -260,7 +260,7 @@ describe('identifier', () => {
             type: 'INSERT',
             executionType: 'MODIFICATION',
             parameters: [],
-            tables: [],
+            tables: ['Persons'],
           },
           {
             start: 79,

--- a/test/identifier/single-statement.spec.ts
+++ b/test/identifier/single-statement.spec.ts
@@ -1033,7 +1033,7 @@ describe('identifier', () => {
           type: 'INSERT',
           executionType: 'MODIFICATION',
           parameters: [],
-          tables: [],
+          tables: ['Persons'],
         },
       ];
 

--- a/test/identifier/single-statement.spec.ts
+++ b/test/identifier/single-statement.spec.ts
@@ -65,7 +65,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [],
-          tables: ["[Pers;\'ons]"],
+          tables: ["[Pers;'ons]"],
         },
       ];
 
@@ -492,7 +492,7 @@ describe('identifier', () => {
                   type: 'DROP_PROCEDURE',
                   executionType: 'MODIFICATION',
                   parameters: [],
-                  tables: []
+                  tables: [],
                 },
               ];
               expect(actual).to.eql(expected);

--- a/test/identifier/single-statement.spec.ts
+++ b/test/identifier/single-statement.spec.ts
@@ -413,6 +413,7 @@ describe('identifier', () => {
                 type: 'CREATE_PROCEDURE',
                 executionType: 'MODIFICATION',
                 parameters: [],
+                tables: ['mydataset.customers'], // FIXME: currently returns mydataset
               },
             ];
             expect(actual).to.eql(expected);
@@ -438,6 +439,7 @@ describe('identifier', () => {
               type: 'CREATE_PROCEDURE',
               executionType: 'MODIFICATION',
               parameters: [],
+              tables: ['mydataset.customers'], // FIXME: currently returns mydataset
             },
           ];
           expect(actual).to.eql(expected);
@@ -473,6 +475,7 @@ describe('identifier', () => {
                   type: 'DROP_PROCEDURE',
                   executionType: 'MODIFICATION',
                   parameters: [],
+                  tables: []
                 },
               ];
               expect(actual).to.eql(expected);
@@ -501,6 +504,7 @@ describe('identifier', () => {
                 type: 'ALTER_PROCEDURE',
                 executionType: 'MODIFICATION',
                 parameters: [],
+                tables: [],
               },
             ];
             expect(actual).to.eql(expected);
@@ -1254,6 +1258,7 @@ describe('identifier', () => {
             type: 'SELECT',
             executionType: 'LISTING',
             parameters: [],
+            tables: ['table'] // FIXME: currently returns cte_name as table
           },
         ];
 
@@ -1275,6 +1280,7 @@ describe('identifier', () => {
             type: 'SELECT',
             executionType: 'LISTING',
             parameters: [],
+            tables: [] // FIXME: currently returns cte_name as table
           },
         ];
 
@@ -1313,6 +1319,7 @@ describe('identifier', () => {
             type: 'SELECT',
             executionType: 'LISTING',
             parameters: [],
+            tables: [], // FIXME - this currently returns cte1, cte2, cte3 as tables
           },
         ];
 

--- a/test/identifier/single-statement.spec.ts
+++ b/test/identifier/single-statement.spec.ts
@@ -14,6 +14,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [],
+          tables: ['Persons'],
         },
       ];
 
@@ -30,6 +31,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [],
+          tables: ['Persons'],
         },
       ];
 
@@ -46,6 +48,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [],
+          tables: ['"Pers;\'ons"'],
         },
       ];
 
@@ -62,6 +65,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [],
+          tables: ["[Pers;\'ons]"],
         },
       ];
 
@@ -81,6 +85,7 @@ describe('identifier', () => {
               type: `CREATE_${type}`,
               executionType: 'MODIFICATION',
               parameters: [],
+              tables: [],
             },
           ];
 
@@ -105,6 +110,7 @@ describe('identifier', () => {
           type: 'CREATE_TABLE',
           executionType: 'MODIFICATION',
           parameters: [],
+          tables: [],
         },
       ];
 
@@ -122,6 +128,7 @@ describe('identifier', () => {
             type: 'CREATE_VIEW',
             executionType: 'MODIFICATION',
             parameters: [],
+            tables: [],
           },
         ];
 
@@ -141,6 +148,7 @@ describe('identifier', () => {
                 type: 'CREATE_VIEW',
                 executionType: 'MODIFICATION',
                 parameters: [],
+                tables: [],
               },
             ];
 
@@ -170,6 +178,7 @@ describe('identifier', () => {
                 type: 'CREATE_VIEW',
                 executionType: 'MODIFICATION',
                 parameters: [],
+                tables: [],
               },
             ];
 
@@ -206,6 +215,7 @@ describe('identifier', () => {
                   type: 'CREATE_VIEW',
                   executionType: 'MODIFICATION',
                   parameters: [],
+                  tables: [],
                 },
               ];
 
@@ -237,6 +247,7 @@ describe('identifier', () => {
                 type: 'CREATE_VIEW',
                 executionType: 'MODIFICATION',
                 parameters: [],
+                tables: [],
               },
             ];
 
@@ -258,6 +269,7 @@ describe('identifier', () => {
                 type: 'CREATE_VIEW',
                 executionType: 'MODIFICATION',
                 parameters: [],
+                tables: [],
               },
             ];
 
@@ -281,6 +293,7 @@ describe('identifier', () => {
             type: 'CREATE_TRIGGER',
             executionType: 'MODIFICATION',
             parameters: [],
+            tables: [],
           },
         ];
         expect(actual).to.eql(expected);
@@ -306,6 +319,7 @@ describe('identifier', () => {
             type: 'CREATE_TRIGGER',
             executionType: 'MODIFICATION',
             parameters: [],
+            tables: [],
           },
         ];
         expect(actual).to.eql(expected);
@@ -340,6 +354,7 @@ describe('identifier', () => {
             type: 'CREATE_TRIGGER',
             executionType: 'MODIFICATION',
             parameters: [],
+            tables: [],
           },
         ];
         expect(actual).to.eql(expected);
@@ -357,6 +372,7 @@ describe('identifier', () => {
             type: 'CREATE_TRIGGER',
             executionType: 'MODIFICATION',
             parameters: [],
+            tables: [],
           },
         ];
         expect(actual).to.eql(expected);
@@ -386,6 +402,7 @@ describe('identifier', () => {
                   type: 'CREATE_PROCEDURE',
                   executionType: 'MODIFICATION',
                   parameters: [],
+                  tables: [],
                 },
               ];
               expect(actual).to.eql(expected);
@@ -413,7 +430,7 @@ describe('identifier', () => {
                 type: 'CREATE_PROCEDURE',
                 executionType: 'MODIFICATION',
                 parameters: [],
-                tables: ['mydataset.customers'], // FIXME: currently returns mydataset
+                tables: [], // FIXME: should return mydataset.customers
               },
             ];
             expect(actual).to.eql(expected);
@@ -439,7 +456,7 @@ describe('identifier', () => {
               type: 'CREATE_PROCEDURE',
               executionType: 'MODIFICATION',
               parameters: [],
-              tables: ['mydataset.customers'], // FIXME: currently returns mydataset
+              tables: [],
             },
           ];
           expect(actual).to.eql(expected);
@@ -579,6 +596,7 @@ describe('identifier', () => {
                 type: `SHOW_${type}`,
                 executionType: 'LISTING',
                 parameters: [],
+                tables: [],
               },
             ];
 
@@ -626,6 +644,7 @@ describe('identifier', () => {
             type: 'CREATE_FUNCTION',
             executionType: 'MODIFICATION',
             parameters: [],
+            tables: [],
           },
         ];
         expect(actual).to.eql(expected);
@@ -676,6 +695,7 @@ describe('identifier', () => {
             type: 'CREATE_FUNCTION',
             executionType: 'MODIFICATION',
             parameters: [],
+            tables: [],
           },
         ];
         expect(actual).to.eql(expected);
@@ -700,6 +720,7 @@ describe('identifier', () => {
             type: 'CREATE_FUNCTION',
             executionType: 'MODIFICATION',
             parameters: [],
+            tables: [],
           },
         ];
 
@@ -718,6 +739,7 @@ describe('identifier', () => {
             type: 'CREATE_FUNCTION',
             executionType: 'MODIFICATION',
             parameters: [],
+            tables: [],
           },
         ];
         expect(actual).to.eql(expected);
@@ -736,6 +758,7 @@ describe('identifier', () => {
             type: 'CREATE_FUNCTION',
             executionType: 'MODIFICATION',
             parameters: [],
+            tables: [],
           },
         ];
         expect(actual).to.eql(expected);
@@ -769,6 +792,7 @@ describe('identifier', () => {
             type: 'CREATE_FUNCTION',
             executionType: 'MODIFICATION',
             parameters: [],
+            tables: [],
           },
         ];
         expect(actual).to.eql(expected);
@@ -787,6 +811,7 @@ describe('identifier', () => {
             type: 'CREATE_INDEX',
             executionType: 'MODIFICATION',
             parameters: [],
+            tables: [],
           },
         ];
         expect(actual).to.eql(expected);
@@ -803,6 +828,7 @@ describe('identifier', () => {
             type: 'CREATE_INDEX',
             executionType: 'MODIFICATION',
             parameters: [],
+            tables: [],
           },
         ];
         expect(actual).to.eql(expected);
@@ -821,6 +847,7 @@ describe('identifier', () => {
                 type: 'CREATE_INDEX',
                 executionType: 'MODIFICATION',
                 parameters: [],
+                tables: [],
               },
             ];
             expect(actual).to.eql(expected);
@@ -841,6 +868,7 @@ describe('identifier', () => {
                 type: 'CREATE_INDEX',
                 executionType: 'MODIFICATION',
                 parameters: [],
+                tables: [],
               },
             ];
             expect(actual).to.eql(expected);
@@ -862,6 +890,7 @@ describe('identifier', () => {
               type: `DROP_${type}`,
               executionType: 'MODIFICATION',
               parameters: [],
+              tables: [],
             },
           ];
 
@@ -886,6 +915,7 @@ describe('identifier', () => {
           type: 'DROP_TABLE',
           executionType: 'MODIFICATION',
           parameters: [],
+          tables: [],
         },
       ];
 
@@ -902,6 +932,7 @@ describe('identifier', () => {
           type: 'DROP_VIEW',
           executionType: 'MODIFICATION',
           parameters: [],
+          tables: [],
         },
       ];
 
@@ -918,6 +949,7 @@ describe('identifier', () => {
           type: 'DROP_DATABASE',
           executionType: 'MODIFICATION',
           parameters: [],
+          tables: [],
         },
       ];
 
@@ -934,6 +966,7 @@ describe('identifier', () => {
           type: 'DROP_TRIGGER',
           executionType: 'MODIFICATION',
           parameters: [],
+          tables: [],
         },
       ];
       expect(actual).to.eql(expected);
@@ -950,6 +983,7 @@ describe('identifier', () => {
           type: 'DROP_FUNCTION',
           executionType: 'MODIFICATION',
           parameters: [],
+          tables: [],
         },
       ];
       expect(actual).to.eql(expected);
@@ -966,6 +1000,7 @@ describe('identifier', () => {
           type: 'DROP_INDEX',
           executionType: 'MODIFICATION',
           parameters: [],
+          tables: [],
         },
       ];
       expect(actual).to.eql(expected);
@@ -981,6 +1016,7 @@ describe('identifier', () => {
           type: 'TRUNCATE',
           executionType: 'MODIFICATION',
           parameters: [],
+          tables: [],
         },
       ];
 
@@ -997,6 +1033,7 @@ describe('identifier', () => {
           type: 'INSERT',
           executionType: 'MODIFICATION',
           parameters: [],
+          tables: [],
         },
       ];
 
@@ -1013,6 +1050,7 @@ describe('identifier', () => {
           type: 'UPDATE',
           executionType: 'MODIFICATION',
           parameters: [],
+          tables: [],
         },
       ];
 
@@ -1031,6 +1069,7 @@ describe('identifier', () => {
           type: 'UPDATE',
           executionType: 'MODIFICATION',
           parameters: [],
+          tables: [],
         },
       ];
       expect(actual).to.eql(expected);
@@ -1046,6 +1085,7 @@ describe('identifier', () => {
           type: 'DELETE',
           executionType: 'MODIFICATION',
           parameters: [],
+          tables: [],
         },
       ];
 
@@ -1072,6 +1112,7 @@ describe('identifier', () => {
               type: `ALTER_${type}`,
               executionType: 'MODIFICATION',
               parameters: [],
+              tables: [],
             },
           ];
 
@@ -1109,6 +1150,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [],
+          tables: ['Persons'],
         },
       ];
 
@@ -1130,6 +1172,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [],
+          tables: ['Persons'],
         },
       ];
 
@@ -1151,6 +1194,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [],
+          tables: ['Persons'],
         },
       ];
 
@@ -1170,6 +1214,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [],
+          tables: ['Persons'],
         },
       ];
 
@@ -1190,6 +1235,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [],
+          tables: ['Persons'],
         },
       ];
 
@@ -1212,6 +1258,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [],
+          tables: ['Persons'],
         },
       ];
 
@@ -1236,6 +1283,7 @@ describe('identifier', () => {
           type: 'CREATE_LOGFILE',
           executionType: 'UNKNOWN',
           parameters: [],
+          tables: [],
         },
       ];
 
@@ -1258,7 +1306,7 @@ describe('identifier', () => {
             type: 'SELECT',
             executionType: 'LISTING',
             parameters: [],
-            tables: ['table'] // FIXME: currently returns cte_name as table
+            tables: [],
           },
         ];
 
@@ -1280,7 +1328,7 @@ describe('identifier', () => {
             type: 'SELECT',
             executionType: 'LISTING',
             parameters: [],
-            tables: [] // FIXME: currently returns cte_name as table
+            tables: [], // FIXME: should return 'table'?
           },
         ];
 
@@ -1319,7 +1367,7 @@ describe('identifier', () => {
             type: 'SELECT',
             executionType: 'LISTING',
             parameters: [],
-            tables: [], // FIXME - this currently returns cte1, cte2, cte3 as tables
+            tables: [],
           },
         ];
 
@@ -1348,6 +1396,7 @@ describe('identifier', () => {
             type: 'SELECT',
             executionType: 'LISTING',
             parameters: [],
+            tables: [],
           },
         ];
 
@@ -1368,6 +1417,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: ['$1', '$2'],
+          tables: ['Persons'],
         },
       ];
 
@@ -1387,6 +1437,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: ['$1', '$2'],
+          tables: ['foo'],
         },
       ];
 
@@ -1406,6 +1457,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [':one', ':two'],
+          tables: ['Persons'],
         },
       ];
 
@@ -1425,6 +1477,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: ['?', '?', '?'],
+          tables: ['Persons'],
         },
       ];
 
@@ -1444,6 +1497,7 @@ describe('identifier', () => {
           type: 'UNKNOWN',
           executionType: 'UNKNOWN',
           parameters: [],
+          tables: [],
         },
       ];
 
@@ -1468,6 +1522,7 @@ describe('identifier', () => {
           type: 'CREATE_PROCEDURE',
           executionType: 'MODIFICATION',
           parameters: [],
+          tables: [],
         },
       ];
 
@@ -1485,6 +1540,7 @@ describe('identifier', () => {
           type: 'UNKNOWN',
           executionType: 'UNKNOWN',
           parameters: [],
+          tables: [],
         },
       ];
 

--- a/test/identifier/single-statement.spec.ts
+++ b/test/identifier/single-statement.spec.ts
@@ -14,7 +14,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [],
-          tables: ['Persons'],
+          tables: [],
         },
       ];
 
@@ -31,7 +31,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [],
-          tables: ['Persons'],
+          tables: [],
         },
       ];
 
@@ -48,7 +48,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [],
-          tables: ['"Pers;\'ons"'],
+          tables: [],
         },
       ];
 
@@ -65,7 +65,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [],
-          tables: ["[Pers;'ons]"],
+          tables: [],
         },
       ];
 
@@ -1033,7 +1033,7 @@ describe('identifier', () => {
           type: 'INSERT',
           executionType: 'MODIFICATION',
           parameters: [],
-          tables: ['Persons'],
+          tables: [],
         },
       ];
 
@@ -1150,7 +1150,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [],
-          tables: ['Persons'],
+          tables: [],
         },
       ];
 
@@ -1172,7 +1172,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [],
-          tables: ['Persons'],
+          tables: [],
         },
       ];
 
@@ -1194,7 +1194,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [],
-          tables: ['Persons'],
+          tables: [],
         },
       ];
 
@@ -1214,7 +1214,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [],
-          tables: ['Persons'],
+          tables: [],
         },
       ];
 
@@ -1235,7 +1235,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [],
-          tables: ['Persons'],
+          tables: [],
         },
       ];
 
@@ -1258,7 +1258,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [],
-          tables: ['Persons'],
+          tables: [],
         },
       ];
 
@@ -1417,7 +1417,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: ['$1', '$2'],
-          tables: ['Persons'],
+          tables: [],
         },
       ];
 
@@ -1437,7 +1437,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: ['$1', '$2', '$3', '$4'],
-          tables: ['foo'],
+          tables: [],
         },
       ];
 
@@ -1457,7 +1457,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [':one', ':two'],
-          tables: ['Persons'],
+          tables: [],
         },
       ];
 
@@ -1477,7 +1477,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [':one', ':two', ':three'],
-          tables: ['Persons'],
+          tables: [],
         },
       ];
 
@@ -1497,7 +1497,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: ['?', '?', '?'],
-          tables: ['Persons'],
+          tables: [],
         },
       ];
 

--- a/test/identifier/single-statement.spec.ts
+++ b/test/identifier/single-statement.spec.ts
@@ -1436,8 +1436,6 @@ describe('identifier', () => {
           text: 'SELECT $1,$2 FROM foo WHERE foo.id in ($3, $4)',
           type: 'SELECT',
           executionType: 'LISTING',
-          parameters: ['$1', '$2'],
-          tables: ['foo'],
           parameters: ['$1', '$2', '$3', '$4'],
           tables: ['foo'],
         },
@@ -1479,6 +1477,7 @@ describe('identifier', () => {
           type: 'SELECT',
           executionType: 'LISTING',
           parameters: [':one', ':two', ':three'],
+          tables: ['Persons'],
         },
       ];
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -17,7 +17,23 @@ describe('identify', () => {
         type: 'SELECT',
         executionType: 'LISTING',
         parameters: ['$1', '$2'],
-        tables: ['foo'],
+        tables: [],
+      },
+    ]);
+  });
+
+  it('should identify tables in simple for basic cases', () => {
+    expect(
+      identify('SELECT * FROM foo JOIN bar ON foo.id = bar.id', { identifyTables: true }),
+    ).to.eql([
+      {
+        start: 0,
+        end: 44,
+        text: 'SELECT * FROM foo JOIN bar ON foo.id = bar.id',
+        type: 'SELECT',
+        executionType: 'LISTING',
+        parameters: [],
+        tables: ['foo', 'bar'],
       },
     ]);
   });

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -17,6 +17,7 @@ describe('identify', () => {
         type: 'SELECT',
         executionType: 'LISTING',
         parameters: ['$1', '$2'],
+        tables: ['foo'],
       },
     ]);
   });

--- a/test/parser/multiple-statements.spec.ts
+++ b/test/parser/multiple-statements.spec.ts
@@ -24,6 +24,7 @@ describe('parser', () => {
             executionType: 'MODIFICATION',
             endStatement: ';',
             parameters: [],
+            tables: ['persons'],
           },
           {
             start: 56,
@@ -31,6 +32,7 @@ describe('parser', () => {
             type: 'SELECT',
             executionType: 'LISTING',
             parameters: [],
+            tables: ['persons'],
           },
         ],
         tokens: [
@@ -93,6 +95,7 @@ describe('parser', () => {
             executionType: 'MODIFICATION',
             endStatement: ';',
             parameters: [],
+            tables: ['persons'],
           },
           {
             start: 74,
@@ -100,6 +103,7 @@ describe('parser', () => {
             type: 'SELECT',
             executionType: 'LISTING',
             parameters: [],
+            tables: ['persons'],
           },
         ],
         tokens: [

--- a/test/parser/multiple-statements.spec.ts
+++ b/test/parser/multiple-statements.spec.ts
@@ -24,7 +24,7 @@ describe('parser', () => {
             executionType: 'MODIFICATION',
             endStatement: ';',
             parameters: [],
-            tables: ['Persons'],
+            tables: [],
           },
           {
             start: 56,
@@ -32,7 +32,7 @@ describe('parser', () => {
             type: 'SELECT',
             executionType: 'LISTING',
             parameters: [],
-            tables: ['Persons'],
+            tables: [],
           },
         ],
         tokens: [
@@ -95,7 +95,7 @@ describe('parser', () => {
             executionType: 'MODIFICATION',
             endStatement: ';',
             parameters: [],
-            tables: ['Persons'],
+            tables: [],
           },
           {
             start: 74,
@@ -103,7 +103,7 @@ describe('parser', () => {
             type: 'SELECT',
             executionType: 'LISTING',
             parameters: [],
-            tables: ['Persons'],
+            tables: [],
           },
         ],
         tokens: [

--- a/test/parser/multiple-statements.spec.ts
+++ b/test/parser/multiple-statements.spec.ts
@@ -24,7 +24,7 @@ describe('parser', () => {
             executionType: 'MODIFICATION',
             endStatement: ';',
             parameters: [],
-            tables: [],
+            tables: ['Persons'],
           },
           {
             start: 56,
@@ -95,7 +95,7 @@ describe('parser', () => {
             executionType: 'MODIFICATION',
             endStatement: ';',
             parameters: [],
-            tables: [],
+            tables: ['Persons'],
           },
           {
             start: 74,

--- a/test/parser/multiple-statements.spec.ts
+++ b/test/parser/multiple-statements.spec.ts
@@ -24,7 +24,7 @@ describe('parser', () => {
             executionType: 'MODIFICATION',
             endStatement: ';',
             parameters: [],
-            tables: ['persons'],
+            tables: [],
           },
           {
             start: 56,
@@ -32,7 +32,7 @@ describe('parser', () => {
             type: 'SELECT',
             executionType: 'LISTING',
             parameters: [],
-            tables: ['persons'],
+            tables: ['Persons'],
           },
         ],
         tokens: [
@@ -95,7 +95,7 @@ describe('parser', () => {
             executionType: 'MODIFICATION',
             endStatement: ';',
             parameters: [],
-            tables: ['persons'],
+            tables: [],
           },
           {
             start: 74,
@@ -103,7 +103,7 @@ describe('parser', () => {
             type: 'SELECT',
             executionType: 'LISTING',
             parameters: [],
-            tables: ['persons'],
+            tables: ['Persons'],
           },
         ],
         tokens: [

--- a/test/parser/single-statements.spec.ts
+++ b/test/parser/single-statements.spec.ts
@@ -217,6 +217,7 @@ describe('parser', () => {
                   executionType: 'MODIFICATION',
                   endStatement: ';',
                   parameters: [],
+                  tables: [],
                 },
               ],
               tokens: [
@@ -281,6 +282,7 @@ describe('parser', () => {
             executionType: 'MODIFICATION',
             endStatement: ';',
             parameters: [],
+            tables: [],
           },
         ],
         tokens: [

--- a/test/parser/single-statements.spec.ts
+++ b/test/parser/single-statements.spec.ts
@@ -5,7 +5,7 @@ import { parse } from '../../src/parser';
 import { Token } from '../../src/defines';
 
 describe('parser', () => {
-  describe('given is a not reconized statement', () => {
+  describe('given is a not recognized statement', () => {
     it('should throw an error including the unknown statement', () => {
       expect(() => parse('LIST * FROM Persons')).to.throw('Invalid statement parser "LIST"');
     });
@@ -23,6 +23,7 @@ describe('parser', () => {
               start: 0,
               end: 14,
               parameters: [],
+              tables: ['foo'],
               type: 'UNKNOWN',
               executionType: 'UNKNOWN',
             },
@@ -43,6 +44,7 @@ describe('parser', () => {
               start: 0,
               end: 19,
               parameters: [],
+              tables: ['foo'],
               type: 'UNKNOWN',
               executionType: 'UNKNOWN',
             },
@@ -73,6 +75,7 @@ describe('parser', () => {
             type: 'SELECT',
             executionType: 'LISTING',
             parameters: [],
+            tables: ['persons']
           },
         ],
         tokens: [
@@ -110,6 +113,7 @@ describe('parser', () => {
             type: 'SELECT',
             executionType: 'LISTING',
             parameters: [],
+            tables: ['persons']
           },
         ],
         tokens: [
@@ -148,6 +152,7 @@ describe('parser', () => {
             executionType: 'MODIFICATION',
             endStatement: ';',
             parameters: [],
+            tables: [], // FIXME: should be ['persons']
           },
         ],
         tokens: [
@@ -204,6 +209,7 @@ describe('parser', () => {
             executionType: 'MODIFICATION',
             endStatement: ';',
             parameters: [],
+            tables: [],
           },
         ],
         tokens: [
@@ -266,6 +272,7 @@ describe('parser', () => {
             executionType: 'MODIFICATION',
             endStatement: ';',
             parameters: [],
+            tables: [] // FIXME: should be ['persons']
           },
         ],
         tokens: [
@@ -322,6 +329,7 @@ describe('parser', () => {
             executionType: 'MODIFICATION',
             endStatement: ';',
             parameters: [],
+            tables: [],
           },
         ],
         tokens: [
@@ -383,6 +391,7 @@ describe('parser', () => {
             executionType: 'MODIFICATION',
             endStatement: ';',
             parameters: [],
+            tables: ['persons']
           },
         ],
         tokens: [
@@ -427,6 +436,7 @@ describe('parser', () => {
             executionType: 'MODIFICATION',
             endStatement: ';',
             parameters: [],
+            tables: [] // FIXME: should be ['persons']
           },
         ],
         tokens: [
@@ -471,6 +481,7 @@ describe('parser', () => {
             executionType: 'MODIFICATION',
             endStatement: ';',
             parameters: [],
+            tables: ['persons'],
           },
         ],
         tokens: [
@@ -515,6 +526,7 @@ describe('parser', () => {
             executionType: 'MODIFICATION',
             endStatement: ';',
             parameters: [],
+            tables: [], // FIXME: should be ['persons']
           },
         ],
         tokens: [

--- a/test/parser/single-statements.spec.ts
+++ b/test/parser/single-statements.spec.ts
@@ -75,7 +75,7 @@ describe('parser', () => {
             type: 'SELECT',
             executionType: 'LISTING',
             parameters: [],
-            tables: ['Persons']
+            tables: ['Persons'],
           },
         ],
         tokens: [
@@ -113,7 +113,7 @@ describe('parser', () => {
             type: 'SELECT',
             executionType: 'LISTING',
             parameters: [],
-            tables: ['Persons']
+            tables: ['Persons'],
           },
         ],
         tokens: [
@@ -391,7 +391,7 @@ describe('parser', () => {
             executionType: 'MODIFICATION',
             endStatement: ';',
             parameters: [],
-            tables: ['Persons']
+            tables: ['Persons'],
           },
         ],
         tokens: [

--- a/test/parser/single-statements.spec.ts
+++ b/test/parser/single-statements.spec.ts
@@ -23,7 +23,7 @@ describe('parser', () => {
               start: 0,
               end: 14,
               parameters: [],
-              tables: ['foo'],
+              tables: [],
               type: 'UNKNOWN',
               executionType: 'UNKNOWN',
             },
@@ -44,7 +44,7 @@ describe('parser', () => {
               start: 0,
               end: 19,
               parameters: [],
-              tables: ['foo'],
+              tables: [],
               type: 'UNKNOWN',
               executionType: 'UNKNOWN',
             },
@@ -75,7 +75,7 @@ describe('parser', () => {
             type: 'SELECT',
             executionType: 'LISTING',
             parameters: [],
-            tables: ['persons']
+            tables: ['Persons']
           },
         ],
         tokens: [
@@ -113,7 +113,7 @@ describe('parser', () => {
             type: 'SELECT',
             executionType: 'LISTING',
             parameters: [],
-            tables: ['persons']
+            tables: ['Persons']
           },
         ],
         tokens: [
@@ -152,7 +152,7 @@ describe('parser', () => {
             executionType: 'MODIFICATION',
             endStatement: ';',
             parameters: [],
-            tables: [], // FIXME: should be ['persons']
+            tables: [],
           },
         ],
         tokens: [
@@ -272,7 +272,7 @@ describe('parser', () => {
             executionType: 'MODIFICATION',
             endStatement: ';',
             parameters: [],
-            tables: [] // FIXME: should be ['persons']
+            tables: [],
           },
         ],
         tokens: [
@@ -391,7 +391,7 @@ describe('parser', () => {
             executionType: 'MODIFICATION',
             endStatement: ';',
             parameters: [],
-            tables: ['persons']
+            tables: []
           },
         ],
         tokens: [
@@ -436,7 +436,7 @@ describe('parser', () => {
             executionType: 'MODIFICATION',
             endStatement: ';',
             parameters: [],
-            tables: [] // FIXME: should be ['persons']
+            tables: [],
           },
         ],
         tokens: [
@@ -481,7 +481,7 @@ describe('parser', () => {
             executionType: 'MODIFICATION',
             endStatement: ';',
             parameters: [],
-            tables: ['persons'],
+            tables: [],
           },
         ],
         tokens: [
@@ -526,7 +526,7 @@ describe('parser', () => {
             executionType: 'MODIFICATION',
             endStatement: ';',
             parameters: [],
-            tables: [], // FIXME: should be ['persons']
+            tables: [],
           },
         ],
         tokens: [

--- a/test/parser/single-statements.spec.ts
+++ b/test/parser/single-statements.spec.ts
@@ -75,7 +75,7 @@ describe('parser', () => {
             type: 'SELECT',
             executionType: 'LISTING',
             parameters: [],
-            tables: ['Persons'],
+            tables: [],
           },
         ],
         tokens: [
@@ -113,7 +113,7 @@ describe('parser', () => {
             type: 'SELECT',
             executionType: 'LISTING',
             parameters: [],
-            tables: ['Persons'],
+            tables: [],
           },
         ],
         tokens: [
@@ -521,7 +521,7 @@ describe('parser', () => {
             executionType: 'MODIFICATION',
             endStatement: ';',
             parameters: [],
-            tables: ['Persons'],
+            tables: [],
           },
         ],
         tokens: [

--- a/test/parser/single-statements.spec.ts
+++ b/test/parser/single-statements.spec.ts
@@ -391,7 +391,7 @@ describe('parser', () => {
             executionType: 'MODIFICATION',
             endStatement: ';',
             parameters: [],
-            tables: []
+            tables: ['Persons']
           },
         ],
         tokens: [


### PR DESCRIPTION
This is a follow up PR for #69 (couldn't push commits to the original PR.)

Most of the stuff here is just updating the tests and limiting the table identification to simple queries using `SELECT`, `INSERT`, and non CTE. These are the stuff we'll need for now.