### PR TITLE
Add support to allow parameters to be database-agnostic

### DIFF
--- a/src/defines.ts
+++ b/src/defines.ts
@@ -79,6 +79,7 @@ export type ExecutionType = 'LISTING' | 'MODIFICATION' | 'INFORMATION' | 'ANON_B
 export interface IdentifyOptions {
   strict?: boolean;
   dialect?: Dialect;
+  enableCrossDBParameters?: boolean;
 }
 
 export interface IdentifyResult {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,12 +16,16 @@ export type {
 export function identify(query: string, options: IdentifyOptions = {}): IdentifyResult[] {
   const isStrict = typeof options.strict === 'undefined' ? true : options.strict === true;
   const dialect = typeof options.dialect === 'undefined' ? 'generic' : options.dialect;
+  const enableCrossDBParameters =
+    typeof options.enableCrossDBParameters === 'undefined'
+      ? false
+      : options.enableCrossDBParameters;
 
   if (!DIALECTS.includes(dialect)) {
     throw new Error(`Unknown dialect. Allowed values: ${DIALECTS.join(', ')}`);
   }
 
-  const result = parse(query, isStrict, dialect);
+  const result = parse(query, isStrict, dialect, enableCrossDBParameters);
 
   return result.body.map((statement) => {
     const result: IdentifyResult = {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -121,11 +121,15 @@ function createInitialStatement(): Statement {
   };
 }
 
-function nextNonWhitespaceToken(state: State): Token {
+function nextNonWhitespaceToken(
+  state: State,
+  dialect: Dialect,
+  enableCrossDBparameters: boolean,
+): Token {
   let token: Token;
   do {
     state = initState({ prevState: state });
-    token = scanToken(state);
+    token = scanToken(state, dialect, enableCrossDBparameters);
   } while (token.type === 'whitespace');
   return token;
 }
@@ -133,7 +137,12 @@ function nextNonWhitespaceToken(state: State): Token {
 /**
  * Parser
  */
-export function parse(input: string, isStrict = true, dialect: Dialect = 'generic'): ParseResult {
+export function parse(
+  input: string,
+  isStrict = true,
+  dialect: Dialect = 'generic',
+  enableCrossDBParameters = false,
+): ParseResult {
   const topLevelState = initState({ input });
   const topLevelStatement: ParseResult = {
     type: 'QUERY',
@@ -163,8 +172,8 @@ export function parse(input: string, isStrict = true, dialect: Dialect = 'generi
 
   while (prevState.position < topLevelState.end) {
     const tokenState = initState({ prevState });
-    const token = scanToken(tokenState, dialect);
-    const nextToken = nextNonWhitespaceToken(tokenState);
+    const token = scanToken(tokenState, dialect, enableCrossDBParameters);
+    const nextToken = nextNonWhitespaceToken(tokenState, dialect, enableCrossDBParameters);
 
     if (!statementParser) {
       // ignore blank tokens before the start of a CTE / not part of a statement

--- a/test/parser/single-statements.spec.ts
+++ b/test/parser/single-statements.spec.ts
@@ -879,6 +879,62 @@ describe('parser', () => {
         expect(actual.tokens).to.eql(expected);
         expect(actual.body[0].parameters).to.eql([':foo', ':bar']);
       });
+
+      it('should extract multiple parameters non strictly', () => {
+        const actual = parse(
+          'select x from a where x = ? and y = :foo and z = $1',
+          true,
+          'generic',
+          true,
+        );
+        actual.tokens = aggregateUnknownTokens(actual.tokens);
+        const expected: Token[] = [
+          {
+            type: 'keyword',
+            value: 'select',
+            start: 0,
+            end: 5,
+          },
+          {
+            type: 'unknown',
+            value: ' x from a where x = ',
+            start: 6,
+            end: 25,
+          },
+          {
+            type: 'parameter',
+            value: '?',
+            start: 26,
+            end: 26,
+          },
+          {
+            type: 'unknown',
+            value: ' and y = ',
+            start: 27,
+            end: 35,
+          },
+          {
+            type: 'parameter',
+            value: ':foo',
+            start: 36,
+            end: 39,
+          },
+          {
+            type: 'unknown',
+            value: ' and z = ',
+            start: 40,
+            end: 48,
+          },
+          {
+            type: 'parameter',
+            value: '$1',
+            start: 49,
+            end: 50,
+          },
+        ];
+        expect(actual.tokens).to.eql(expected);
+        expect(actual.body[0].parameters).to.eql(['?', ':foo', '$1']);
+      });
     });
   });
 });


### PR DESCRIPTION
In reference to https://github.com/beekeeper-studio/beekeeper-studio/issues/1353

Adding support to enable detecting parameters without being tied to specific database type.

```js
identify('select * from my_table where ? = :foo and $1 = $2', { enableCrossDBParameters: true })
``` 