### PR TITLE
Config option to allow custom parameter syntax

### DIFF
--- a/src/defines.ts
+++ b/src/defines.ts
@@ -76,10 +76,21 @@ export type StatementType =
 
 export type ExecutionType = 'LISTING' | 'MODIFICATION' | 'INFORMATION' | 'ANON_BLOCK' | 'UNKNOWN';
 
+export interface ParamTypes {
+  positional?: boolean,
+  numbered?: Array<"?" | ":" | "$">,
+  named?: Array<":" | "@" | "$">,
+  quoted?: Array<":" | "@" | "$">,
+  // regex is for identifying that it is a param, key is how the token is translated to an object value for the formatter,
+  // may not be necessary here, we shal see
+  custom?: Array<{regex: string, key?: (text: string) => string }>
+}
+
 export interface IdentifyOptions {
   strict?: boolean;
   dialect?: Dialect;
   identifyTables?: boolean;
+  paramTypes?: ParamTypes
 }
 
 export interface IdentifyResult {

--- a/src/defines.ts
+++ b/src/defines.ts
@@ -81,9 +81,8 @@ export interface ParamTypes {
   numbered?: Array<"?" | ":" | "$">,
   named?: Array<":" | "@" | "$">,
   quoted?: Array<":" | "@" | "$">,
-  // regex is for identifying that it is a param, key is how the token is translated to an object value for the formatter,
-  // may not be necessary here, we shal see
-  custom?: Array<{regex: string, key?: (text: string) => string }>
+  // regex for identifying that it is a param
+  custom?: Array<string>
 }
 
 export interface IdentifyOptions {

--- a/src/defines.ts
+++ b/src/defines.ts
@@ -77,19 +77,19 @@ export type StatementType =
 export type ExecutionType = 'LISTING' | 'MODIFICATION' | 'INFORMATION' | 'ANON_BLOCK' | 'UNKNOWN';
 
 export interface ParamTypes {
-  positional?: boolean,
-  numbered?: Array<"?" | ":" | "$">,
-  named?: Array<":" | "@" | "$">,
-  quoted?: Array<":" | "@" | "$">,
+  positional?: boolean;
+  numbered?: Array<'?' | ':' | '$'>;
+  named?: Array<':' | '@' | '$'>;
+  quoted?: Array<':' | '@' | '$'>;
   // regex for identifying that it is a param
-  custom?: Array<string>
+  custom?: Array<string>;
 }
 
 export interface IdentifyOptions {
   strict?: boolean;
   dialect?: Dialect;
   identifyTables?: boolean;
-  paramTypes?: ParamTypes
+  paramTypes?: ParamTypes;
 }
 
 export interface IdentifyResult {

--- a/src/defines.ts
+++ b/src/defines.ts
@@ -78,11 +78,11 @@ export type ExecutionType = 'LISTING' | 'MODIFICATION' | 'INFORMATION' | 'ANON_B
 
 export interface ParamTypes {
   positional?: boolean;
-  numbered?: Array<'?' | ':' | '$'>;
-  named?: Array<':' | '@' | '$'>;
-  quoted?: Array<':' | '@' | '$'>;
+  numbered?: ('?' | ':' | '$')[];
+  named?: (':' | '@' | '$')[];
+  quoted?: (':' | '@' | '$')[];
   // regex for identifying that it is a param
-  custom?: Array<string>;
+  custom?: string[];
 }
 
 export interface IdentifyOptions {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,10 +21,8 @@ export function identify(query: string, options: IdentifyOptions = {}): Identify
     throw new Error(`Unknown dialect. Allowed values: ${DIALECTS.join(', ')}`);
   }
 
-  let paramTypes: ParamTypes;
-
   // Default parameter types for each dialect
-  paramTypes = options.paramTypes || defaultParamTypesFor(dialect);
+  const paramTypes = options.paramTypes || defaultParamTypesFor(dialect);
 
   const result = parse(query, isStrict, dialect, options.identifyTables, paramTypes);
   const sort = dialect === 'psql' && !options.paramTypes;

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ export function identify(query: string, options: IdentifyOptions = {}): Identify
     throw new Error(`Unknown dialect. Allowed values: ${DIALECTS.join(', ')}`);
   }
 
-  const result = parse(query, isStrict, dialect, options.identifyTables);
+  const result = parse(query, isStrict, dialect, options.identifyTables, options.paramTypes);
 
   return result.body.map((statement) => {
     const result: IdentifyResult = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-import { parse, EXECUTION_TYPES } from './parser';
-import { DIALECTS } from './defines';
+import { parse, EXECUTION_TYPES, defaultParamTypesFor } from './parser';
+import { DIALECTS, ParamTypes } from './defines';
 import type { ExecutionType, IdentifyOptions, IdentifyResult, StatementType } from './defines';
 
 export type {
@@ -21,7 +21,16 @@ export function identify(query: string, options: IdentifyOptions = {}): Identify
     throw new Error(`Unknown dialect. Allowed values: ${DIALECTS.join(', ')}`);
   }
 
-  const result = parse(query, isStrict, dialect, options.identifyTables, options.paramTypes);
+  let paramTypes: ParamTypes;
+
+  // Default parameter types for each dialect
+  if (options.paramTypes) {
+    paramTypes = options.paramTypes;
+  } else {
+    paramTypes = defaultParamTypesFor(dialect);
+  }
+
+  const result = parse(query, isStrict, dialect, options.identifyTables, paramTypes);
   const sort = dialect === 'psql' && !options.paramTypes;
 
   return result.body.map((statement) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { parse, EXECUTION_TYPES, defaultParamTypesFor } from './parser';
-import { DIALECTS, ParamTypes } from './defines';
+import { DIALECTS } from './defines';
 import type { ExecutionType, IdentifyOptions, IdentifyResult, StatementType } from './defines';
 
 export type {

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,11 +24,7 @@ export function identify(query: string, options: IdentifyOptions = {}): Identify
   let paramTypes: ParamTypes;
 
   // Default parameter types for each dialect
-  if (options.paramTypes) {
-    paramTypes = options.paramTypes;
-  } else {
-    paramTypes = defaultParamTypesFor(dialect);
-  }
+  paramTypes = options.paramTypes || defaultParamTypesFor(dialect);
 
   const result = parse(query, isStrict, dialect, options.identifyTables, paramTypes);
   const sort = dialect === 'psql' && !options.paramTypes;

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ export function identify(query: string, options: IdentifyOptions = {}): Identify
   }
 
   const result = parse(query, isStrict, dialect, options.identifyTables, options.paramTypes);
+  const sort = dialect === 'psql' && !options.paramTypes;
 
   return result.body.map((statement) => {
     const result: IdentifyResult = {
@@ -31,7 +32,7 @@ export function identify(query: string, options: IdentifyOptions = {}): Identify
       type: statement.type,
       executionType: statement.executionType,
       // we want to sort the postgres params: $1 $2 $3, regardless of the order they appear
-      parameters: dialect === 'psql' ? statement.parameters.sort() : statement.parameters,
+      parameters: sort ? statement.parameters.sort() : statement.parameters,
       tables: statement.tables || [],
     };
     return result;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1015,3 +1015,25 @@ function stateMachineStatementParser(
     },
   };
 }
+
+export function defaultParamTypesFor(dialect: Dialect): ParamTypes {
+  if (dialect === 'psql') {
+    return {
+      numbered: ['$'],
+    };
+  } else if (dialect === 'mssql') {
+    return {
+      named: [':'],
+    };
+  } else if (dialect === 'bigquery') {
+    return {
+      positional: true,
+      named: ['@'],
+      quoted: ['@'],
+    };
+  } else {
+    return {
+      positional: true,
+    };
+  }
+}

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -145,7 +145,7 @@ export function parse(
   isStrict = true,
   dialect: Dialect = 'generic',
   identifyTables = false,
-  paramTypes?: ParamTypes
+  paramTypes?: ParamTypes,
 ): ParseResult {
   const topLevelState = initState({ input });
   const topLevelStatement: ParseResult = {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -9,6 +9,7 @@ import type {
   Step,
   ParseResult,
   ConcreteStatement,
+  ParamTypes,
 } from './defines';
 
 interface StatementParser {
@@ -144,6 +145,7 @@ export function parse(
   isStrict = true,
   dialect: Dialect = 'generic',
   identifyTables = false,
+  paramTypes?: ParamTypes
 ): ParseResult {
   const topLevelState = initState({ input });
   const topLevelStatement: ParseResult = {
@@ -174,7 +176,7 @@ export function parse(
 
   while (prevState.position < topLevelState.end) {
     const tokenState = initState({ prevState });
-    const token = scanToken(tokenState, dialect);
+    const token = scanToken(tokenState, dialect, paramTypes);
     const nextToken = nextNonWhitespaceToken(tokenState, dialect);
 
     if (!statementParser) {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1017,23 +1017,30 @@ function stateMachineStatementParser(
 }
 
 export function defaultParamTypesFor(dialect: Dialect): ParamTypes {
-  if (dialect === 'psql') {
-    return {
-      numbered: ['$'],
-    };
-  } else if (dialect === 'mssql') {
-    return {
-      named: [':'],
-    };
-  } else if (dialect === 'bigquery') {
-    return {
-      positional: true,
-      named: ['@'],
-      quoted: ['@'],
-    };
-  } else {
-    return {
-      positional: true,
-    };
+  switch (dialect) {
+    case 'psql':
+      return {
+        numbered: ['$'],
+      };
+    case 'mssql':
+      return {
+        named: [':'],
+      };
+    case 'bigquery':
+      return {
+        positional: true,
+        named: ['@'],
+        quoted: ['@'],
+      };
+    case 'sqlite':
+      return {
+        positional: true,
+        numbered: ['?'],
+        named: [':', '@'],
+      };
+    default:
+      return {
+        positional: true,
+      };
   }
 }

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -457,10 +457,7 @@ function isString(ch: Char, dialect: Dialect): boolean {
   return stringStart.includes(ch);
 }
 
-function isCustomParam(
-  state: State,
-  customParamType: NonNullable<ParamTypes['custom']>,
-): boolean | undefined {
+function isCustomParam(state: State, customParamType: NonNullable<ParamTypes['custom']>): boolean {
   return customParamType.some((regex) => {
     const reg = new RegExp(`^(?:${regex})`, 'uy');
     return reg.test(state.input.slice(state.start));

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -472,8 +472,7 @@ function isCustomParam(state: State, paramTypes: ParamTypes): boolean | undefine
 function isParameter(ch: Char, state: State, paramTypes: ParamTypes): boolean {
   const curCh: any = ch;
   const nextChar = peek(state);
-  if (paramTypes.positional && ch === '?')
-    return true;
+  if (paramTypes.positional && ch === '?') return true;
 
   if (paramTypes.numbered && paramTypes.numbered.length && paramTypes.numbered.includes(curCh)) {
     if (nextChar !== null && !isNaN(Number(nextChar))) {

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -269,11 +269,11 @@ function getCustomParam(state: State, paramTypes: ParamTypes): string | null | u
 }
 
 function scanParameter(state: State, dialect: Dialect, paramTypes: ParamTypes): Token {
-  const curCh: any = state.input[state.start];
+  const curCh = state.input[state.start];
   const nextChar = peek(state);
   let matched = false;
 
-  if (paramTypes.numbered && paramTypes.numbered.length && paramTypes.numbered.includes(curCh)) {
+  if (paramTypes.numbered?.length && paramTypes.numbered.some((type) => type === curCh)) {
     const endIndex = state.input
       .slice(state.start + 1)
       .split('')
@@ -293,19 +293,14 @@ function scanParameter(state: State, dialect: Dialect, paramTypes: ParamTypes): 
     }
   }
 
-  if (!matched && paramTypes.named && paramTypes.named.length && paramTypes.named.includes(curCh)) {
+  if (!matched && paramTypes.named?.length && paramTypes.named.some((type) => type === curCh)) {
     if (!isQuotedIdentifier(nextChar, dialect)) {
       while (isAlphaNumeric(peek(state))) read(state);
       matched = true;
     }
   }
 
-  if (
-    !matched &&
-    paramTypes.quoted &&
-    paramTypes.quoted.length &&
-    paramTypes.quoted.includes(curCh)
-  ) {
+  if (!matched && paramTypes.quoted?.length && paramTypes.quoted.some((type) => type === curCh)) {
     if (isQuotedIdentifier(nextChar, dialect)) {
       const quoteChar = read(state) as string;
       // end when we reach the end quote
@@ -462,32 +457,37 @@ function isString(ch: Char, dialect: Dialect): boolean {
   return stringStart.includes(ch);
 }
 
-function isCustomParam(state: State, paramTypes: ParamTypes): boolean | undefined {
-  return paramTypes?.custom?.some((regex) => {
+function isCustomParam(
+  state: State,
+  customParamType: NonNullable<ParamTypes['custom']>,
+): boolean | undefined {
+  return customParamType.some((regex) => {
     const reg = new RegExp(`^(?:${regex})`, 'uy');
     return reg.test(state.input.slice(state.start));
   });
 }
 
 function isParameter(ch: Char, state: State, paramTypes: ParamTypes): boolean {
-  const curCh: any = ch;
+  if (!ch) {
+    return false;
+  }
   const nextChar = peek(state);
   if (paramTypes.positional && ch === '?') return true;
 
-  if (paramTypes.numbered && paramTypes.numbered.length && paramTypes.numbered.includes(curCh)) {
+  if (paramTypes.numbered?.length && paramTypes.numbered.some((type) => ch === type)) {
     if (nextChar !== null && !isNaN(Number(nextChar))) {
       return true;
     }
   }
 
   if (
-    (paramTypes.named && paramTypes.named.length && paramTypes.named.includes(curCh)) ||
-    (paramTypes.quoted && paramTypes.quoted.length && paramTypes.quoted.includes(curCh))
+    (paramTypes.named?.length && paramTypes.named.some((type) => type === ch)) ||
+    (paramTypes.quoted?.length && paramTypes.quoted.some((type) => type === ch))
   ) {
     return true;
   }
 
-  if (paramTypes.custom && paramTypes.custom.length && isCustomParam(state, paramTypes)) {
+  if (paramTypes.custom?.length && isCustomParam(state, paramTypes.custom)) {
     return true;
   }
 

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -331,18 +331,18 @@ function scanParameter(state: State, dialect: Dialect, paramTypes: ParamTypes): 
       matched = true;
     }
   }
+  const value = state.input.slice(state.start, state.position + 1);
 
   if (!matched && !paramTypes.positional && curCh !== '?') {
     // not positional, panic
     return {
-      type: 'parameter',
-      value: 'unknown',
+      type: 'unknown',
+      value: value,
       start: state.start,
-      end: state.end,
+      end: state.start + value.length - 1,
     };
   }
 
-  const value = state.input.slice(state.start, state.position + 1);
   return {
     type: 'parameter',
     value,

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -46,6 +46,26 @@ describe('identify', () => {
     ]);
   });
 
+  it('custom params should override defaults for dialect', () => {
+    const paramTypes: ParamTypes = {
+      positional: true
+    };
+
+    const query = 'SELECT * FROM foo WHERE bar = $1 AND bar = :named AND fizz = :`quoted`';
+
+    expect(identify(query, { dialect: 'psql', paramTypes })).to.eql([
+      {
+        start: 0,
+        end: 69,
+        text: query,
+        type: 'SELECT',
+        executionType: 'LISTING',
+        parameters: [],
+        tables: []
+      }
+    ])
+  })
+
   it('should identify tables in simple for basic cases', () => {
     expect(
       identify('SELECT * FROM foo JOIN bar ON foo.id = bar.id', { identifyTables: true }),

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -48,7 +48,7 @@ describe('identify', () => {
 
   it('custom params should override defaults for dialect', () => {
     const paramTypes: ParamTypes = {
-      positional: true
+      positional: true,
     };
 
     const query = 'SELECT * FROM foo WHERE bar = $1 AND bar = :named AND fizz = :`quoted`';
@@ -61,10 +61,10 @@ describe('identify', () => {
         type: 'SELECT',
         executionType: 'LISTING',
         parameters: [],
-        tables: []
-      }
-    ])
-  })
+        tables: [],
+      },
+    ]);
+  });
 
   it('should identify tables in simple for basic cases', () => {
     expect(

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,5 +1,6 @@
 import { Dialect, getExecutionType, identify } from '../src/index';
 import { expect } from 'chai';
+import { ParamTypes } from '../src/defines';
 
 describe('identify', () => {
   it('should throw error for invalid dialect', () => {
@@ -21,6 +22,29 @@ describe('identify', () => {
       },
     ]);
   });
+
+  it('should identify custom parameters', () => {
+    const paramTypes: ParamTypes = {
+      positional: true,
+      numbered: ['$'],
+      named: [':'],
+      quoted: [':'],
+      custom: [ '\\{[a-zA-Z0-9_]+\\}' ]
+    };
+    const query = `SELECT * FROM foo WHERE bar = ? AND baz = $1 AND fizz = :fizzz  AND buzz = :"buzz buzz" AND foo2 = {fooo}`;
+
+    expect(identify(query, { dialect: 'psql', paramTypes })).to.eql([
+      {
+        start: 0,
+        end: 104,
+        text: query,
+        type: 'SELECT',
+        executionType: 'LISTING',
+        parameters: ['?', '$1', ':fizzz', ':"buzz buzz"', '{fooo}'],
+        tables: []
+      }
+    ])
+  })
 
   it('should identify tables in simple for basic cases', () => {
     expect(

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -29,7 +29,7 @@ describe('identify', () => {
       numbered: ['$'],
       named: [':'],
       quoted: [':'],
-      custom: [ '\\{[a-zA-Z0-9_]+\\}' ]
+      custom: ['\\{[a-zA-Z0-9_]+\\}'],
     };
     const query = `SELECT * FROM foo WHERE bar = ? AND baz = $1 AND fizz = :fizzz  AND buzz = :"buzz buzz" AND foo2 = {fooo}`;
 
@@ -41,10 +41,10 @@ describe('identify', () => {
         type: 'SELECT',
         executionType: 'LISTING',
         parameters: ['?', '$1', ':fizzz', ':"buzz buzz"', '{fooo}'],
-        tables: []
-      }
-    ])
-  })
+        tables: [],
+      },
+    ]);
+  });
 
   it('should identify tables in simple for basic cases', () => {
     expect(

--- a/test/parser/single-statements.spec.ts
+++ b/test/parser/single-statements.spec.ts
@@ -725,7 +725,13 @@ describe('parser', () => {
       });
 
       it('should extract PSQL parameters', () => {
-        const actual = parse('select x from a where x = $1', true, 'psql', false, defaultParamTypesFor('psql'));
+        const actual = parse(
+          'select x from a where x = $1',
+          true,
+          'psql',
+          false,
+          defaultParamTypesFor('psql'),
+        );
         actual.tokens = aggregateUnknownTokens(actual.tokens);
         const expected: Token[] = [
           {
@@ -752,7 +758,13 @@ describe('parser', () => {
       });
 
       it('should extract multiple PSQL parameters', () => {
-        const actual = parse('select x from a where x = $1 and y = $2', true, 'psql', false, defaultParamTypesFor('psql'));
+        const actual = parse(
+          'select x from a where x = $1 and y = $2',
+          true,
+          'psql',
+          false,
+          defaultParamTypesFor('psql'),
+        );
         actual.tokens = aggregateUnknownTokens(actual.tokens);
         const expected: Token[] = [
           {
@@ -791,7 +803,13 @@ describe('parser', () => {
       });
 
       it('should extract mssql parameters', () => {
-        const actual = parse('select x from a where x = :foo', true, 'mssql', false, defaultParamTypesFor('mssql'));
+        const actual = parse(
+          'select x from a where x = :foo',
+          true,
+          'mssql',
+          false,
+          defaultParamTypesFor('mssql'),
+        );
         actual.tokens = aggregateUnknownTokens(actual.tokens);
         const expected: Token[] = [
           {
@@ -856,7 +874,13 @@ describe('parser', () => {
       });
 
       it('should extract multiple mssql parameters', () => {
-        const actual = parse('select x from a where x = :foo and y = :bar', true, 'mssql', false, defaultParamTypesFor('mssql'));
+        const actual = parse(
+          'select x from a where x = :foo and y = :bar',
+          true,
+          'mssql',
+          false,
+          defaultParamTypesFor('mssql'),
+        );
         actual.tokens = aggregateUnknownTokens(actual.tokens);
         const expected: Token[] = [
           {

--- a/test/parser/single-statements.spec.ts
+++ b/test/parser/single-statements.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 
 import { aggregateUnknownTokens } from '../spec-helper';
-import { parse } from '../../src/parser';
+import { defaultParamTypesFor, parse } from '../../src/parser';
 import { Token } from '../../src/defines';
 
 describe('parser', () => {
@@ -725,7 +725,7 @@ describe('parser', () => {
       });
 
       it('should extract PSQL parameters', () => {
-        const actual = parse('select x from a where x = $1', true, 'psql');
+        const actual = parse('select x from a where x = $1', true, 'psql', false, defaultParamTypesFor('psql'));
         actual.tokens = aggregateUnknownTokens(actual.tokens);
         const expected: Token[] = [
           {
@@ -752,7 +752,7 @@ describe('parser', () => {
       });
 
       it('should extract multiple PSQL parameters', () => {
-        const actual = parse('select x from a where x = $1 and y = $2', true, 'psql');
+        const actual = parse('select x from a where x = $1 and y = $2', true, 'psql', false, defaultParamTypesFor('psql'));
         actual.tokens = aggregateUnknownTokens(actual.tokens);
         const expected: Token[] = [
           {
@@ -791,7 +791,7 @@ describe('parser', () => {
       });
 
       it('should extract mssql parameters', () => {
-        const actual = parse('select x from a where x = :foo', true, 'mssql');
+        const actual = parse('select x from a where x = :foo', true, 'mssql', false, defaultParamTypesFor('mssql'));
         actual.tokens = aggregateUnknownTokens(actual.tokens);
         const expected: Token[] = [
           {
@@ -856,7 +856,7 @@ describe('parser', () => {
       });
 
       it('should extract multiple mssql parameters', () => {
-        const actual = parse('select x from a where x = :foo and y = :bar', true, 'mssql');
+        const actual = parse('select x from a where x = :foo and y = :bar', true, 'mssql', false, defaultParamTypesFor('mssql'));
         actual.tokens = aggregateUnknownTokens(actual.tokens);
         const expected: Token[] = [
           {

--- a/test/tokenizer/index.spec.ts
+++ b/test/tokenizer/index.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { scanToken } from '../../src/tokenizer';
-import type { Dialect } from '../../src/defines';
+import type { Dialect, ParamTypes } from '../../src/defines';
 
 describe('scan', () => {
   const initState = (input: string) => ({
@@ -375,6 +375,217 @@ describe('scan', () => {
             },
           },
         ].forEach(({ actual, expected }) => expect(actual).to.eql(expected));
+      });
+
+      describe('custom parameters', () => {
+        it('should allow positional parameters for all dialects', () => {
+          const paramTypes: ParamTypes = {
+            positional: true
+          };
+
+          const expected = {
+            type: 'parameter',
+            value: '?',
+            start: 0,
+            end: 0
+          };
+
+
+          (['mssql', 'psql', 'oracle', 'bigquery', 'sqlite', 'mysql', 'generic'] as Array<Dialect>).forEach((dialect) => {
+            [
+              {
+                actual: scanToken(initState('?'), dialect, paramTypes),
+                expected,
+              },
+            ].forEach(({ actual, expected }) => expect(actual).to.eql(expected));
+          });
+        });
+
+        it('should allow numeric parameters for all dialects', () => {
+          const paramTypes: ParamTypes = {
+            numbered: ["$", "?", ":"]
+          };
+
+          const expected = [
+            {
+              type: 'parameter',
+              value: '$1',
+              start: 0,
+              end: 1
+            },
+            {
+              type: 'parameter',
+              value: '?1',
+              start: 0,
+              end: 1
+            },
+            {
+              type: 'parameter',
+              value: ':1',
+              start: 0,
+              end: 1
+            },
+            {
+              type: 'parameter',
+              value: 'unknown',
+              start: 0,
+              end: 8
+            }
+          ];
+
+          (['mssql', 'psql', 'oracle', 'bigquery', 'sqlite', 'mysql', 'generic'] as Array<Dialect>).forEach((dialect) => {
+            [
+              {
+                actual: scanToken(initState('$1'), dialect, paramTypes),
+                expected: expected[0],
+              },
+              {
+                actual: scanToken(initState('?1'), dialect, paramTypes),
+                expected: expected[1],
+              },
+              {
+                actual: scanToken(initState(':1'), dialect, paramTypes),
+                expected: expected[2],
+              },
+              {
+                actual: scanToken(initState('$123hello'), dialect, paramTypes), // won't recognize
+                expected: expected[3]
+              }
+            ].forEach(({ actual, expected }) => expect(actual).to.eql(expected));
+          });
+        });
+
+        it('should allow named parameters for all dialects', () => {
+          const paramTypes: ParamTypes = {
+            named: ["$", "@", ":"]
+          };
+
+          const expected = [
+            {
+              type: 'parameter',
+              value: '$namedParam',
+              start: 0,
+              end: 10
+            },
+            {
+              type: 'parameter',
+              value: '@namedParam',
+              start: 0,
+              end: 10
+            },
+            {
+              type: 'parameter',
+              value: ':namedParam',
+              start: 0,
+              end: 10
+            },
+            {
+              type: 'parameter',
+              value: '$123hello', // allow starting with a number
+              start: 0,
+              end: 8
+            }
+          ];
+
+          (['mssql', 'psql', 'oracle', 'bigquery', 'sqlite', 'mysql', 'generic'] as Array<Dialect>).forEach((dialect) => {
+            [
+              {
+                actual: scanToken(initState('$namedParam'), dialect, paramTypes),
+                expected: expected[0],
+              },
+              {
+                actual: scanToken(initState('@namedParam'), dialect, paramTypes),
+                expected: expected[1],
+              },
+              {
+                actual: scanToken(initState(':namedParam'), dialect, paramTypes),
+                expected: expected[2],
+              },
+              {
+                actual: scanToken(initState('$123hello'), dialect, paramTypes),
+                expected: expected[3]
+              }
+            ].forEach(({ actual, expected }) => expect(actual).to.eql(expected));
+          })
+        });
+
+        // this test will need a refactor depending on how we want to implement quotes
+        it('should allow quoted parameters for all dialects', () => {
+          const paramTypes: ParamTypes = {
+            quoted: ["$", "@", ":"]
+          };
+
+          const expected = [
+            {
+              type: 'parameter',
+              value: '$',
+              start: 0,
+              end: 14
+            },
+            {
+              type: 'parameter',
+              value: '@',
+              start: 0,
+              end: 14
+            },
+            {
+              type: 'parameter',
+              value: ':',
+              start: 0,
+              end: 14
+            }
+          ];
+
+          ([
+            { dialect: 'mssql', quotes: ['""', '[]'] },
+            { dialect: 'psql', quotes: ['""', '``'] },
+            { dialect: 'oracle', quotes: ['""', '``']},
+            { dialect: 'bigquery', quotes: ['""', '``']},
+            { dialect: 'sqlite', quotes: ['""', '``']},
+            { dialect: 'mysql', quotes: ['""', '``']},
+            { dialect: 'generic', quotes: ['""', '``']},
+          ] as Array<{dialect: Dialect, quotes: Array<string>}>).forEach(({dialect, quotes}) => {
+            const dialectExpected = expected.map((exp) => {
+              return quotes.map((quote) => {
+                return {
+                  ...exp,
+                  value: `${exp.value}${quote[0]}quoted param${quote[1]}`
+                }
+              })
+            }).flat();
+            dialectExpected.map((expected) => ({
+              actual: scanToken(initState(expected.value), dialect, paramTypes),
+              expected
+            })).forEach(({ actual, expected }) => expect(actual).to.eql(expected));
+          })
+        });
+
+        it('should allow custom parameters for all dialects', () => {
+          const paramTypes: ParamTypes = {
+            custom: [{ regex: '\\{[a-zA-Z0-9_]+\\}' }]
+          };
+
+          const expected = {
+            type: 'parameter',
+            value: '{namedParam}',
+            start: 0,
+            end: 11
+          };
+
+          (['mssql', 'psql', 'oracle', 'bigquery', 'sqlite', 'mysql', 'generic'] as Array<Dialect>).forEach((dialect) => {
+            expect(scanToken(initState('{namedParam}'), dialect, paramTypes)).to.eql(expected);
+          })
+        });
+
+        it('should not have collision between param types', () => {
+          const paramTypes: ParamTypes = {
+            positional: true,
+            numbered: [':'],
+            named: [':'],
+            quoted: [':'],
+            custom: []
+          };
+        })
       });
     });
   });

--- a/test/tokenizer/index.spec.ts
+++ b/test/tokenizer/index.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { scanToken } from '../../src/tokenizer';
-import type { Dialect, ParamTypes } from '../../src/defines';
+import type { Dialect, ParamTypes, Token } from '../../src/defines';
 
 describe('scan', () => {
   const initState = (input: string) => ({
@@ -380,18 +380,19 @@ describe('scan', () => {
       describe('custom parameters', () => {
         it('should allow positional parameters for all dialects', () => {
           const paramTypes: ParamTypes = {
-            positional: true
+            positional: true,
           };
 
           const expected = {
             type: 'parameter',
             value: '?',
             start: 0,
-            end: 0
+            end: 0,
           };
 
-
-          (['mssql', 'psql', 'oracle', 'bigquery', 'sqlite', 'mysql', 'generic'] as Array<Dialect>).forEach((dialect) => {
+          (
+            ['mssql', 'psql', 'oracle', 'bigquery', 'sqlite', 'mysql', 'generic'] as Array<Dialect>
+          ).forEach((dialect) => {
             [
               {
                 actual: scanToken(initState('?'), dialect, paramTypes),
@@ -403,7 +404,7 @@ describe('scan', () => {
 
         it('should allow numeric parameters for all dialects', () => {
           const paramTypes: ParamTypes = {
-            numbered: ["$", "?", ":"]
+            numbered: ['$', '?', ':'],
           };
 
           const expected = [
@@ -411,29 +412,31 @@ describe('scan', () => {
               type: 'parameter',
               value: '$1',
               start: 0,
-              end: 1
+              end: 1,
             },
             {
               type: 'parameter',
               value: '?1',
               start: 0,
-              end: 1
+              end: 1,
             },
             {
               type: 'parameter',
               value: ':1',
               start: 0,
-              end: 1
+              end: 1,
             },
             {
               type: 'parameter',
               value: 'unknown',
               start: 0,
-              end: 8
-            }
+              end: 8,
+            },
           ];
 
-          (['mssql', 'psql', 'oracle', 'bigquery', 'sqlite', 'mysql', 'generic'] as Array<Dialect>).forEach((dialect) => {
+          (
+            ['mssql', 'psql', 'oracle', 'bigquery', 'sqlite', 'mysql', 'generic'] as Array<Dialect>
+          ).forEach((dialect) => {
             [
               {
                 actual: scanToken(initState('$1'), dialect, paramTypes),
@@ -449,15 +452,15 @@ describe('scan', () => {
               },
               {
                 actual: scanToken(initState('$123hello'), dialect, paramTypes), // won't recognize
-                expected: expected[3]
-              }
+                expected: expected[3],
+              },
             ].forEach(({ actual, expected }) => expect(actual).to.eql(expected));
           });
         });
 
         it('should allow named parameters for all dialects', () => {
           const paramTypes: ParamTypes = {
-            named: ["$", "@", ":"]
+            named: ['$', '@', ':'],
           };
 
           const expected = [
@@ -465,29 +468,31 @@ describe('scan', () => {
               type: 'parameter',
               value: '$namedParam',
               start: 0,
-              end: 10
+              end: 10,
             },
             {
               type: 'parameter',
               value: '@namedParam',
               start: 0,
-              end: 10
+              end: 10,
             },
             {
               type: 'parameter',
               value: ':namedParam',
               start: 0,
-              end: 10
+              end: 10,
             },
             {
               type: 'parameter',
               value: '$123hello', // allow starting with a number
               start: 0,
-              end: 8
-            }
+              end: 8,
+            },
           ];
 
-          (['mssql', 'psql', 'oracle', 'bigquery', 'sqlite', 'mysql', 'generic'] as Array<Dialect>).forEach((dialect) => {
+          (
+            ['mssql', 'psql', 'oracle', 'bigquery', 'sqlite', 'mysql', 'generic'] as Array<Dialect>
+          ).forEach((dialect) => {
             [
               {
                 actual: scanToken(initState('$namedParam'), dialect, paramTypes),
@@ -503,78 +508,87 @@ describe('scan', () => {
               },
               {
                 actual: scanToken(initState('$123hello'), dialect, paramTypes),
-                expected: expected[3]
-              }
+                expected: expected[3],
+              },
             ].forEach(({ actual, expected }) => expect(actual).to.eql(expected));
-          })
+          });
         });
 
         // this test will need a refactor depending on how we want to implement quotes
         it('should allow quoted parameters for all dialects', () => {
           const paramTypes: ParamTypes = {
-            quoted: ["$", "@", ":"]
+            quoted: ['$', '@', ':'],
           };
 
-          const expected = [
+          const expected: Array<Token> = [
             {
               type: 'parameter',
               value: '$',
               start: 0,
-              end: 14
+              end: 14,
             },
             {
               type: 'parameter',
               value: '@',
               start: 0,
-              end: 14
+              end: 14,
             },
             {
               type: 'parameter',
               value: ':',
               start: 0,
-              end: 14
-            }
+              end: 14,
+            },
           ];
 
-          ([
-            { dialect: 'mssql', quotes: ['""', '[]'] },
-            { dialect: 'psql', quotes: ['""', '``'] },
-            { dialect: 'oracle', quotes: ['""', '``']},
-            { dialect: 'bigquery', quotes: ['""', '``']},
-            { dialect: 'sqlite', quotes: ['""', '``']},
-            { dialect: 'mysql', quotes: ['""', '``']},
-            { dialect: 'generic', quotes: ['""', '``']},
-          ] as Array<{dialect: Dialect, quotes: Array<string>}>).forEach(({dialect, quotes}) => {
-            const dialectExpected = expected.map((exp) => {
-              return quotes.map((quote) => {
-                return {
-                  ...exp,
-                  value: `${exp.value}${quote[0]}quoted param${quote[1]}`
-                }
-              })
-            }).flat();
-            dialectExpected.map((expected) => ({
-              actual: scanToken(initState(expected.value), dialect, paramTypes),
-              expected
-            })).forEach(({ actual, expected }) => expect(actual).to.eql(expected));
-          })
+          (
+            [
+              { dialect: 'mssql', quotes: ['""', '[]'] },
+              { dialect: 'psql', quotes: ['""', '``'] },
+              { dialect: 'oracle', quotes: ['""', '``'] },
+              { dialect: 'bigquery', quotes: ['""', '``'] },
+              { dialect: 'sqlite', quotes: ['""', '``'] },
+              { dialect: 'mysql', quotes: ['""', '``'] },
+              { dialect: 'generic', quotes: ['""', '``'] },
+            ] as Array<{ dialect: Dialect; quotes: Array<string> }>
+          ).forEach(({ dialect, quotes }) => {
+            const dialectExpected = Array.prototype.concat.apply(
+              [],
+              expected.map((exp) => {
+                return quotes.map((quote) => {
+                  return {
+                    ...exp,
+                    value: `${exp.value}${quote[0]}quoted param${quote[1]}`,
+                  };
+                });
+              }),
+            );
+            dialectExpected
+              .map((expected: Token) => ({
+                actual: scanToken(initState(expected.value), dialect, paramTypes),
+                expected,
+              }))
+              .forEach(({ actual, expected }) => expect(actual).to.eql(expected));
+          });
         });
 
         it('should allow custom parameters for all dialects', () => {
           const paramTypes: ParamTypes = {
-            custom: [ '\\{[a-zA-Z0-9_]+\\}' ]
+            custom: ['\\{[a-zA-Z0-9_]+\\}'],
           };
 
           const expected = {
             type: 'parameter',
             value: '{namedParam}',
             start: 0,
-            end: 11
+            end: 11,
           };
 
-          (['mssql', 'psql', 'oracle', 'bigquery', 'sqlite', 'mysql', 'generic'] as Array<Dialect>).forEach((dialect) => {
+          (
+            ['mssql', 'psql', 'oracle', 'bigquery', 'sqlite', 'mysql', 'generic'] as Array<Dialect>
+          ).forEach((dialect) => {
             expect(scanToken(initState('{namedParam}'), dialect, paramTypes)).to.eql(expected);
-          })
+          });
         });
 
         it('should not have collision between param types', () => {
@@ -583,7 +597,7 @@ describe('scan', () => {
             numbered: [':'],
             named: [':'],
             quoted: [':'],
-            custom: []
+            custom: [],
           };
 
           const expected = [
@@ -591,32 +605,32 @@ describe('scan', () => {
               type: 'parameter',
               value: '?',
               start: 0,
-              end: 0
+              end: 0,
             },
             {
               type: 'parameter',
               value: ':123',
               start: 0,
-              end: 3
+              end: 3,
             },
             {
               type: 'parameter',
               value: ':123hello',
               start: 0,
-              end: 8
+              end: 8,
             },
             {
               type: 'parameter',
               value: ':"named param"',
               start: 0,
-              end: 13
-            }
+              end: 13,
+            },
           ];
 
           expected.forEach((expected) => {
             expect(scanToken(initState(expected.value), 'mssql', paramTypes)).to.eql(expected);
-          })
-        })
+          });
+        });
       });
     });
   });

--- a/test/tokenizer/index.spec.ts
+++ b/test/tokenizer/index.spec.ts
@@ -562,7 +562,7 @@ describe('scan', () => {
 
         it('should allow custom parameters for all dialects', () => {
           const paramTypes: ParamTypes = {
-            custom: [{ regex: '\\{[a-zA-Z0-9_]+\\}' }]
+            custom: [ '\\{[a-zA-Z0-9_]+\\}' ]
           };
 
           const expected = {
@@ -585,6 +585,37 @@ describe('scan', () => {
             quoted: [':'],
             custom: []
           };
+
+          const expected = [
+            {
+              type: 'parameter',
+              value: '?',
+              start: 0,
+              end: 0
+            },
+            {
+              type: 'parameter',
+              value: ':123',
+              start: 0,
+              end: 3
+            },
+            {
+              type: 'parameter',
+              value: ':123hello',
+              start: 0,
+              end: 8
+            },
+            {
+              type: 'parameter',
+              value: ':"named param"',
+              start: 0,
+              end: 13
+            }
+          ];
+
+          expected.forEach((expected) => {
+            expect(scanToken(initState(expected.value), 'mssql', paramTypes)).to.eql(expected);
+          })
         })
       });
     });

--- a/test/tokenizer/index.spec.ts
+++ b/test/tokenizer/index.spec.ts
@@ -447,10 +447,10 @@ describe('scan', () => {
               end: 1,
             },
             {
-              type: 'parameter',
-              value: 'unknown',
+              type: 'unknown',
+              value: '$',
               start: 0,
-              end: 8,
+              end: 0,
             },
           ];
 

--- a/test/tokenizer/index.spec.ts
+++ b/test/tokenizer/index.spec.ts
@@ -305,7 +305,6 @@ describe('scan', () => {
       [
         ['?', 'generic'],
         ['?', 'mysql'],
-        ['?', 'sqlite'],
       ].forEach(([ch, dialect]) => {
         it(`should only scan ${ch} from ${ch}1 for ${dialect}`, () => {
           const input = `${ch}1`;


### PR DESCRIPTION
This follows the same syntax that is allowed by sql-formatter, which we use in beekeeper-studio

```ts
interface ParamTypes {
  positional?: boolean, // ansi standard positional '?' parameters
  numbered?: Array<"?" | ":" | "$">, // psql like numeric parametrs '$1'
  named?: Array<":" | "@" | "$">, // mssql like named parameters ':name'
  quoted?: Array<":" | "@" | "$">, // quoted parameters, like bigquery ':`name here`'
  custom?: Array<string> // regex describing a custom parameter, eg. '/\{[a-zA-Z0-9_]+\}/' allows '{name}' as a param
}
```