### PR TITLE
Add DynamoDB PartiQL dialect support

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,24 @@ console.log(statements);
 1. `input (string)`: the whole SQL script text to be processed
 1. `options (object)`: allow to set different configurations
     1. `strict (bool)`: allow disable strict mode which will ignore unknown types *(default=true)*
-    2. `dialect (string)`: Specify your database dialect, values: `generic`, `mysql`, `oracle`, `psql`, `sqlite` and `mssql`. *(default=generic)*
+    2. `dialect (string)`: Specify your database dialect, values: `generic`, `mysql`, `oracle`, `psql`, `sqlite`, `mssql`, `bigquery` and `dynamodb`. *(default=generic)*
+
+### DynamoDB (PartiQL)
+
+DynamoDB exposes a [PartiQL](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.html)-compatible
+query language that is a strict subset of SQL. When `dialect: 'dynamodb'` is used, only DML statements
+are accepted (`SELECT`, `INSERT`, `UPDATE`, `DELETE`); DDL (`CREATE` / `DROP` / `ALTER` / `TRUNCATE`),
+`SHOW`, and transaction-control statements (`BEGIN` / `COMMIT` / `ROLLBACK`) are not part of the
+DynamoDB PartiQL grammar and will throw in strict mode (or fall back to `UNKNOWN` in non-strict mode).
+Positional `?` placeholders are the supported parameter style. Table and index identifiers are
+double-quoted; string and attribute literals are single-quoted, per the DynamoDB PartiQL spec.
+
+```js
+import { identify } from 'sql-query-identifier';
+
+identify(`SELECT * FROM "Orders" WHERE OrderID = ?`, { dialect: 'dynamodb' });
+// [{ type: 'SELECT', executionType: 'LISTING', parameters: ['?'], ... }]
+```
 
 ## Contributing
 

--- a/src/defines.ts
+++ b/src/defines.ts
@@ -5,6 +5,7 @@ export const DIALECTS = [
   'oracle',
   'psql',
   'bigquery',
+  'dynamodb',
   'generic',
 ] as const;
 export type Dialect = (typeof DIALECTS)[number];

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -113,6 +113,7 @@ const blockOpeners: Record<Dialect, string[]> = {
   sqlite: ['BEGIN', 'CASE'],
   oracle: ['DECLARE', 'BEGIN', 'CASE'],
   bigquery: ['BEGIN', 'CASE', 'IF', 'LOOP', 'REPEAT', 'WHILE', 'FOR'],
+  dynamodb: [],
 };
 
 interface ParseOptions {
@@ -325,6 +326,21 @@ function createStatementParserByToken(
   options: ParseOptions,
 ): StatementParser {
   if (token.type === 'keyword') {
+    // DynamoDB PartiQL only supports DML: SELECT, INSERT, UPDATE, DELETE.
+    // No DDL (CREATE/DROP/ALTER/TRUNCATE), SHOW, or transaction control statements
+    // are part of the DynamoDB PartiQL grammar.
+    if (
+      options.dialect === 'dynamodb' &&
+      !['SELECT', 'INSERT', 'UPDATE', 'DELETE'].includes(token.value.toUpperCase())
+    ) {
+      if (!options.isStrict) {
+        return createUnknownStatementParser(options);
+      }
+      throw new Error(
+        `Statement "${token.value}" is not supported by the DynamoDB PartiQL dialect.`,
+      );
+    }
+
     switch (token.value.toUpperCase()) {
       case 'SELECT':
         return createSelectStatementParser(options);
@@ -1152,6 +1168,11 @@ export function defaultParamTypesFor(dialect: Dialect): ParamTypes {
         positional: true,
         numbered: ['?'],
         named: [':', '@'],
+      };
+    case 'dynamodb':
+      // DynamoDB PartiQL supports positional `?` placeholders only.
+      return {
+        positional: true,
       };
     default:
       return {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -329,6 +329,16 @@ function createStatementParserByToken(
     // DynamoDB PartiQL only supports DML: SELECT, INSERT, UPDATE, DELETE.
     // No DDL (CREATE/DROP/ALTER/TRUNCATE), SHOW, or transaction control statements
     // are part of the DynamoDB PartiQL grammar.
+    //
+    // Spec: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.statements.html
+    //   SELECT  https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.select.html
+    //   INSERT  https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.insert.html
+    //   UPDATE  https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.update.html
+    //   DELETE  https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.delete.html
+    // Transactions and batches are exposed as DynamoDB API operations
+    // (ExecuteTransaction / BatchExecuteStatement), not as SQL keywords:
+    //   https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.multiplestatements.transactions.html
+    //   https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.multiplestatements.batching.html
     if (
       options.dialect === 'dynamodb' &&
       !['SELECT', 'INSERT', 'UPDATE', 'DELETE'].includes(token.value.toUpperCase())
@@ -1170,7 +1180,11 @@ export function defaultParamTypesFor(dialect: Dialect): ParamTypes {
         named: [':', '@'],
       };
     case 'dynamodb':
-      // DynamoDB PartiQL supports positional `?` placeholders only.
+      // DynamoDB PartiQL supports positional `?` placeholders only; values are
+      // bound out-of-band via the `Parameters` field on the ExecuteStatement /
+      // ExecuteTransaction / BatchExecuteStatement API calls.
+      // See: https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ExecuteStatement.html
+      //      https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.multiplestatements.batching.html
       return {
         positional: true,
       };

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -5,7 +5,7 @@ import { ParamTypes } from '../src/defines';
 describe('identify', () => {
   it('should throw error for invalid dialect', () => {
     expect(() => identify('SELECT * FROM foo', { dialect: 'invalid' as Dialect })).to.throw(
-      'Unknown dialect. Allowed values: mssql, sqlite, mysql, oracle, psql, bigquery, generic',
+      'Unknown dialect. Allowed values: mssql, sqlite, mysql, oracle, psql, bigquery, dynamodb, generic',
     );
   });
 

--- a/test/parser/dynamodb.spec.ts
+++ b/test/parser/dynamodb.spec.ts
@@ -3,8 +3,20 @@ import { identify } from '../../src/index';
 import { expect } from 'chai';
 
 // DynamoDB supports a subset of PartiQL: only DML (SELECT, INSERT, UPDATE, DELETE).
-// See https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.html
+//
+// Top-level reference:
+//   https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.html
+// Statements overview:
+//   https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.statements.html
 describe('Parser for dynamodb (PartiQL)', () => {
+  // SELECT syntax & examples (incl. "Table"."Index", document paths, IN/BETWEEN/ORDER BY):
+  //   https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.select.html
+  // INSERT syntax (`INSERT INTO table VALUE item`, single-quoted strings/attribute names):
+  //   https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.insert.html
+  // UPDATE syntax (SET / REMOVE / RETURNING [ALL OLD | MODIFIED OLD | ALL NEW | MODIFIED NEW] *):
+  //   https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.update.html
+  // DELETE syntax:
+  //   https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.delete.html
   describe('supported DML statements', () => {
     it('parses a SELECT against a quoted table identifier', () => {
       const sql = `SELECT OrderID, Total FROM "Orders" WHERE OrderID = 1`;
@@ -60,6 +72,9 @@ describe('Parser for dynamodb (PartiQL)', () => {
     });
   });
 
+  // Positional `?` parameters are bound via the `Parameters` field on the
+  // ExecuteStatement / ExecuteTransaction / BatchExecuteStatement APIs:
+  //   https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ExecuteStatement.html
   describe('parameters (positional `?` placeholders)', () => {
     it('captures positional `?` parameters in a SELECT', () => {
       const sql = `SELECT * FROM "Orders" WHERE OrderID = ? AND Address = ?`;
@@ -86,6 +101,11 @@ describe('Parser for dynamodb (PartiQL)', () => {
     });
   });
 
+  // DynamoDB exposes transactions and batches as API operations rather than
+  // SQL keywords, so BEGIN/COMMIT/ROLLBACK and DDL keywords are not part of
+  // the grammar:
+  //   https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.multiplestatements.transactions.html
+  //   https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.multiplestatements.batching.html
   describe('unsupported statements (DDL, transactions, SHOW)', () => {
     [
       'CREATE TABLE foo (id int)',

--- a/test/parser/dynamodb.spec.ts
+++ b/test/parser/dynamodb.spec.ts
@@ -1,0 +1,145 @@
+import { parse } from '../../src/parser';
+import { identify } from '../../src/index';
+import { expect } from 'chai';
+
+// DynamoDB supports a subset of PartiQL: only DML (SELECT, INSERT, UPDATE, DELETE).
+// See https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.html
+describe('Parser for dynamodb (PartiQL)', () => {
+  describe('supported DML statements', () => {
+    it('parses a SELECT against a quoted table identifier', () => {
+      const sql = `SELECT OrderID, Total FROM "Orders" WHERE OrderID = 1`;
+      const result = parse(sql, true, 'dynamodb');
+      expect(result.body.length).to.eql(1);
+      expect(result.body[0].type).to.eql('SELECT');
+      expect(result.body[0].executionType).to.eql('LISTING');
+    });
+
+    it('parses a SELECT querying a secondary index ("Table"."Index")', () => {
+      const sql = `SELECT * FROM "Orders"."OrderIDIndex" WHERE OrderID = 1`;
+      const result = parse(sql, true, 'dynamodb');
+      expect(result.body.length).to.eql(1);
+      expect(result.body[0].type).to.eql('SELECT');
+    });
+
+    it('parses an INSERT ... VALUE { ... } statement', () => {
+      const sql = `INSERT INTO "Music" VALUE {'Artist' : 'Acme Band','SongTitle' : 'PartiQL Rocks'}`;
+      const result = parse(sql, true, 'dynamodb');
+      expect(result.body.length).to.eql(1);
+      expect(result.body[0].type).to.eql('INSERT');
+      expect(result.body[0].executionType).to.eql('MODIFICATION');
+    });
+
+    it('parses an UPDATE ... SET ... WHERE statement', () => {
+      const sql = `UPDATE "Music" SET AwardsWon=1 WHERE Artist='Acme Band' AND SongTitle='PartiQL Rocks'`;
+      const result = parse(sql, true, 'dynamodb');
+      expect(result.body.length).to.eql(1);
+      expect(result.body[0].type).to.eql('UPDATE');
+      expect(result.body[0].executionType).to.eql('MODIFICATION');
+    });
+
+    it('parses an UPDATE ... REMOVE ... statement', () => {
+      const sql = `UPDATE "Music" REMOVE AwardDetail.Grammys[2] WHERE Artist='Acme Band' AND SongTitle='PartiQL Rocks'`;
+      const result = parse(sql, true, 'dynamodb');
+      expect(result.body.length).to.eql(1);
+      expect(result.body[0].type).to.eql('UPDATE');
+    });
+
+    it('parses an UPDATE with RETURNING ALL OLD * clause', () => {
+      const sql = `UPDATE "Music" SET AwardsWon=1 WHERE Artist='Acme Band' AND SongTitle='PartiQL Rocks' RETURNING ALL OLD *`;
+      const result = parse(sql, true, 'dynamodb');
+      expect(result.body.length).to.eql(1);
+      expect(result.body[0].type).to.eql('UPDATE');
+    });
+
+    it('parses a DELETE statement', () => {
+      const sql = `DELETE FROM "Music" WHERE Artist='Acme Band' AND SongTitle='PartiQL Rocks'`;
+      const result = parse(sql, true, 'dynamodb');
+      expect(result.body.length).to.eql(1);
+      expect(result.body[0].type).to.eql('DELETE');
+      expect(result.body[0].executionType).to.eql('MODIFICATION');
+    });
+  });
+
+  describe('parameters (positional `?` placeholders)', () => {
+    it('captures positional `?` parameters in a SELECT', () => {
+      const sql = `SELECT * FROM "Orders" WHERE OrderID = ? AND Address = ?`;
+      const result = parse(sql, true, 'dynamodb');
+      expect(result.body.length).to.eql(1);
+      expect(result.body[0].parameters).to.eql(['?', '?']);
+    });
+
+    it('captures positional `?` parameters in an INSERT', () => {
+      const sql = `INSERT INTO "Music" VALUE {'Artist' : ?, 'SongTitle' : ?}`;
+      const result = parse(sql, true, 'dynamodb');
+      expect(result.body.length).to.eql(1);
+      expect(result.body[0].parameters).to.eql(['?', '?']);
+    });
+  });
+
+  describe('multiple statements', () => {
+    it('parses multiple semicolon-separated DML statements', () => {
+      const sql = `SELECT * FROM "Orders"; UPDATE "Music" SET AwardsWon=1 WHERE Artist='Acme';`;
+      const result = parse(sql, true, 'dynamodb');
+      expect(result.body.length).to.eql(2);
+      expect(result.body[0].type).to.eql('SELECT');
+      expect(result.body[1].type).to.eql('UPDATE');
+    });
+  });
+
+  describe('unsupported statements (DDL, transactions, SHOW)', () => {
+    [
+      'CREATE TABLE foo (id int)',
+      'DROP TABLE foo',
+      'ALTER TABLE foo ADD COLUMN bar int',
+      'TRUNCATE TABLE foo',
+      'SHOW TABLES',
+      'BEGIN TRANSACTION',
+      'COMMIT',
+      'ROLLBACK',
+    ].forEach((sql) => {
+      it(
+        `throws in strict mode for: ${sql.split(' ')[0]} ${sql.split(' ')[1] ?? ''}`.trim(),
+        () => {
+          expect(() => parse(sql, true, 'dynamodb')).to.throw(
+            /not supported by the DynamoDB PartiQL dialect/,
+          );
+        },
+      );
+
+      it(
+        `falls back to UNKNOWN in non-strict mode for: ${sql.split(' ')[0]} ${
+          sql.split(' ')[1] ?? ''
+        }`.trim(),
+        () => {
+          const result = parse(sql, false, 'dynamodb');
+          expect(result.body.length).to.eql(1);
+          expect(result.body[0].type).to.eql('UNKNOWN');
+        },
+      );
+    });
+  });
+
+  describe('public identify() integration', () => {
+    it('identifies a DynamoDB SELECT via the public API', () => {
+      const sql = `SELECT * FROM "Orders" WHERE OrderID = ?`;
+      expect(identify(sql, { dialect: 'dynamodb' })).to.eql([
+        {
+          start: 0,
+          end: sql.length - 1,
+          text: sql,
+          type: 'SELECT',
+          executionType: 'LISTING',
+          parameters: ['?'],
+          tables: [],
+          columns: [],
+        },
+      ]);
+    });
+
+    it('rejects DDL via the public API in strict mode', () => {
+      expect(() => identify('CREATE TABLE foo (id int)', { dialect: 'dynamodb' })).to.throw(
+        /not supported by the DynamoDB PartiQL dialect/,
+      );
+    });
+  });
+});


### PR DESCRIPTION
DynamoDB exposes a PartiQL-compatible query language that is a strict
subset of SQL: only DML (SELECT, INSERT, UPDATE, DELETE) is supported,
with positional `?` placeholders. DDL, SHOW, and transaction-control
statements are not part of the grammar.

- Add `dynamodb` to DIALECTS and route only DML keywords to a parser;
  reject other statement keywords (with a fallback to UNKNOWN in
  non-strict mode).
- Add empty block-openers list and positional-`?` default param type.
- Add parser test coverage for SELECT (incl. "Table"."Index"), INSERT
  ... VALUE, UPDATE SET/REMOVE, RETURNING, DELETE, positional params,
  multi-statement, and rejection of unsupported keywords.
- Document the dialect and its constraints in the README.