### PR TITLE
fix: treat `SELECT ... INTO` as a modification

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -983,6 +983,18 @@ function stateMachineStatementParser(
         statement.parameters.push(token.value);
       }
 
+      // `SELECT ... INTO target` creates and populates a new table, so the
+      // statement modifies the database even though its type is SELECT. Only
+      // dialects where `SELECT INTO` builds a table are flagged here; Oracle
+      // and MySQL use `SELECT INTO` to assign variables, so they are excluded.
+      if (
+        statement.type === 'SELECT' &&
+        token.value.toUpperCase() === 'INTO' &&
+        ['generic', 'mssql', 'psql'].includes(dialect)
+      ) {
+        statement.executionType = 'MODIFICATION';
+      }
+
       if (statement.type && statement.start >= 0) {
         // statement has already been identified
         // just wait until end of the statement

--- a/test/identifier/single-statement.spec.ts
+++ b/test/identifier/single-statement.spec.ts
@@ -76,6 +76,59 @@ describe('identifier', () => {
       expect(actual).to.eql(expected);
     });
 
+    describe('identify "SELECT ... INTO" statements', () => {
+      // `SELECT ... INTO` creates and populates a new table, so it modifies the
+      // database. See https://github.com/coresql/sql-query-identifier/issues/81
+      it('should identify "SELECT ... INTO" as a modification', () => {
+        const sql = 'SELECT * INTO public."MyTable1" FROM public."MyTable2"';
+        const actual = identify(sql);
+        const expected = [
+          {
+            start: 0,
+            end: sql.length - 1,
+            text: sql,
+            type: 'SELECT',
+            executionType: 'MODIFICATION',
+            parameters: [],
+            tables: [],
+            columns: [],
+          },
+        ];
+
+        expect(actual).to.eql(expected);
+      });
+
+      it('should identify "SELECT ... INTO" as a modification in mssql', () => {
+        const sql = 'SELECT id, name INTO [dbo].[copy] FROM [dbo].[users]';
+        const actual = identify(sql, { dialect: 'mssql' });
+
+        expect(actual[0].type).to.eql('SELECT');
+        expect(actual[0].executionType).to.eql('MODIFICATION');
+      });
+
+      it('should identify "SELECT ... INTO" as a modification in psql', () => {
+        const sql = 'SELECT * INTO new_table FROM old_table';
+        const actual = identify(sql, { dialect: 'psql' });
+
+        expect(actual[0].type).to.eql('SELECT');
+        expect(actual[0].executionType).to.eql('MODIFICATION');
+      });
+
+      it('should still identify a plain "SELECT" as a listing', () => {
+        const actual = identify('SELECT * FROM Persons');
+
+        expect(actual[0].executionType).to.eql('LISTING');
+      });
+
+      it('should not flag oracle "SELECT INTO", which assigns variables', () => {
+        const sql = 'SELECT name INTO v_name FROM employees WHERE id = 1';
+        const actual = identify(sql, { dialect: 'oracle' });
+
+        expect(actual[0].type).to.eql('SELECT');
+        expect(actual[0].executionType).to.eql('LISTING');
+      });
+    });
+
     ['DATABASE', 'SCHEMA'].forEach((type) => {
       describe(`identify "CREATE ${type}" statements`, () => {
         const sql = `CREATE ${type} Profile;`;


### PR DESCRIPTION
## Problem

`identify("SELECT * INTO public.\"MyTable1\" FROM public.\"MyTable2\"")` reports `executionType: "LISTING"`, but `SELECT ... INTO` creates and populates a new table — it modifies the database.

The parser derives `executionType` purely from the statement type, and `SELECT` maps to `LISTING`.

Fixes #81.

## Fix

When a `SELECT` statement contains an `INTO` clause, set its `executionType` to `MODIFICATION`. This is gated to the dialects where `SELECT INTO` builds a table — `generic`, `mssql`, `psql`. Oracle and MySQL use `SELECT INTO` to assign values to variables rather than create a table, so they keep the `LISTING` classification (and the existing Oracle PL/SQL block tests are unaffected).

## Tests

Added a `SELECT ... INTO` describe block to `test/identifier/single-statement.spec.ts`:

- `SELECT ... INTO` → `MODIFICATION` (generic — the exact case from #81)
- `SELECT ... INTO` → `MODIFICATION` (mssql)
- `SELECT ... INTO` → `MODIFICATION` (psql)
- a plain `SELECT` still resolves to `LISTING`
- an Oracle `SELECT ... INTO` (variable assignment) stays `LISTING`

The three `MODIFICATION` assertions fail without the parser change; the full suite passes with it.