### PR TITLE
Fix string-bodied CREATE FUNCTION swallowing the next statement

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -119,13 +119,29 @@ export const EXECUTION_TYPES: Record<StatementType, ExecutionType> = {
   ANON_BLOCK: 'ANON_BLOCK',
 };
 
-const statementsWithEnds = [
-  'CREATE_TRIGGER',
-  'CREATE_FUNCTION',
-  'CREATE_PROCEDURE',
-  'ANON_BLOCK',
-  'UNKNOWN',
-];
+// Statement types whose bodies may legitimately contain token-level semicolons
+// (e.g. a BEGIN...END block), so a semicolon does not necessarily terminate them.
+// They only terminate once their body has completed (statement.canEnd) or, for
+// string/dollar-quoted bodies, once that body has been consumed (see the
+// string-body handling in stateMachineStatementParser).
+function getStatementsWithEnds(dialect: Dialect): StatementType[] {
+  const statementsWithEnds: StatementType[] = [
+    'CREATE_FUNCTION',
+    'CREATE_PROCEDURE',
+    'ANON_BLOCK',
+    'UNKNOWN',
+  ];
+
+  // In PostgreSQL and Snowflake a trigger only references a function and never
+  // carries an inline body, so its first semicolon always terminates it. Other
+  // dialects (mssql, mysql, sqlite, ...) support inline BEGIN...END trigger
+  // bodies whose token-level semicolons must not terminate the statement early.
+  if (!['psql', 'snowflake'].includes(dialect)) {
+    statementsWithEnds.push('CREATE_TRIGGER');
+  }
+
+  return statementsWithEnds;
+}
 
 const blockOpeners: Record<Dialect, string[]> = {
   generic: ['BEGIN', 'CASE'],
@@ -1007,6 +1023,8 @@ function stateMachineStatementParser(
   const columnParser = new ColumnParser(dialect);
   const tableParser = new TableParser(dialect);
 
+  const statementsWithEnds = getStatementsWithEnds(dialect);
+
   /* eslint arrow-body-style: 0, no-extra-parens: 0 */
   const isValidToken = (step: Step, token: Token) => {
     if (!step.validation) {
@@ -1078,6 +1096,23 @@ function stateMachineStatementParser(
       if (token.type === 'whitespace') {
         setPrevToken(token);
         return;
+      }
+
+      // A CREATE FUNCTION / PROCEDURE body can be supplied as a quoted or
+      // dollar-quoted string following the AS keyword (e.g. PostgreSQL
+      // `AS 'select 1'` / `AS $$ ... $$`, Snowflake `AS $$ ... $$`). Such a body
+      // is a single token, so it never opens a BEGIN...END block and canEnd would
+      // otherwise never be set, causing the statement to swallow whatever follows.
+      // Once the string body has been consumed at the top level, allow the next
+      // semicolon to terminate the statement.
+      if (
+        token.type === 'string' &&
+        openBlocks === 0 &&
+        prevNonWhitespaceToken?.type === 'keyword' &&
+        prevNonWhitespaceToken.value.toUpperCase() === 'AS' &&
+        (statement.type === 'CREATE_FUNCTION' || statement.type === 'CREATE_PROCEDURE')
+      ) {
+        statement.canEnd = true;
       }
 
       if (

--- a/test/identifier/multiple-statement.spec.ts
+++ b/test/identifier/multiple-statement.spec.ts
@@ -249,6 +249,42 @@ describe('identifier', () => {
       });
     });
 
+    describe('identifying functions with non-block bodies followed by another statement', () => {
+      it('should identify a psql function with a string-literal body then a SELECT', () => {
+        const sql = `create function foo() returns void as 'select 1' language sql;\nSELECT 1;`;
+        const actual = identify(sql, { dialect: 'psql' });
+        expect(actual.map((statement) => statement.type)).to.eql(['CREATE_FUNCTION', 'SELECT']);
+        expect(actual.map((statement) => statement.text)).to.eql([
+          "create function foo() returns void as 'select 1' language sql;",
+          'SELECT 1;',
+        ]);
+      });
+
+      it('should identify a psql function with a dollar-quoted body then a SELECT', () => {
+        const sql = `CREATE FUNCTION myfunc() RETURNS INTEGER AS $$ SELECT 1 $$ LANGUAGE sql;\nSELECT 1;`;
+        const actual = identify(sql, { dialect: 'psql' });
+        expect(actual.map((statement) => statement.type)).to.eql(['CREATE_FUNCTION', 'SELECT']);
+      });
+
+      it('should identify a psql function with a dollar-quoted plpgsql body then a SELECT', () => {
+        const sql = `CREATE FUNCTION f() RETURNS int AS $$ BEGIN RETURN 1; END; $$ LANGUAGE plpgsql;\nSELECT 1;`;
+        const actual = identify(sql, { dialect: 'psql' });
+        expect(actual.map((statement) => statement.type)).to.eql(['CREATE_FUNCTION', 'SELECT']);
+      });
+
+      it('should identify a psql trigger without a block body then a SELECT', () => {
+        const sql = `CREATE TRIGGER t AFTER INSERT ON tbl EXECUTE FUNCTION f();\nSELECT 1;`;
+        const actual = identify(sql, { dialect: 'psql' });
+        expect(actual.map((statement) => statement.type)).to.eql(['CREATE_TRIGGER', 'SELECT']);
+      });
+
+      it('should still keep an mssql BEGIN...END function body intact then a SELECT', () => {
+        const sql = `CREATE FUNCTION dbo.f (@x int) RETURNS int AS BEGIN RETURN @x; END;\nSELECT 1;`;
+        const actual = identify(sql, { dialect: 'mssql' });
+        expect(actual.map((statement) => statement.type)).to.eql(['CREATE_FUNCTION', 'SELECT']);
+      });
+    });
+
     describe('identifying multiple statements with CTEs', () => {
       it('should able to detect queries with a CTE in middle query', () => {
         const actual = identify(


### PR DESCRIPTION
## Problem

The library fails to split the following into two statements:

```sql
create function foo() returns void as 'select 1' language sql;
SELECT 1;
```

It is parsed as a single `CREATE_FUNCTION` that greedily consumes the trailing `SELECT 1;`.

The bug is broader than the single reported case — it affects any `CREATE FUNCTION`/`PROCEDURE` whose body is a quoted or dollar-quoted string (PostgreSQL/Snowflake/standard SQL), and PostgreSQL `CREATE TRIGGER` (which only references a function). These only worked before when they happened to be the *last* statement, since end-of-input terminated them.

## Root cause

`CREATE_FUNCTION`/`CREATE_PROCEDURE`/`CREATE_TRIGGER` are in `statementsWithEnds`, so a semicolon only terminates them once `statement.canEnd` is set — and `canEnd` is only set when a `BEGIN...END` block closes. When the body is a single string/dollar-quoted token (no block) or the trigger has no body, `canEnd` was never set, so the statement swallowed everything after it.

## Fix

- Set `canEnd` once a string/dollar-quoted body has been consumed at the top level following the `AS` keyword (`CREATE FUNCTION`/`PROCEDURE`).
- Make `statementsWithEnds` dialect-aware: exclude `CREATE_TRIGGER` for PostgreSQL/Snowflake, where triggers have no inline body.

The block-based `canEnd` logic is left intact, so T-SQL bodies (e.g. mssql triggers with `IF ... RETURN;` before a `BEGIN...END`) still protect their token-level semicolons.

## Tests

Added a `multiple-statement` describe block covering:
- the reported string-literal body case
- dollar-quoted bodies (incl. dollar-quoted `plpgsql` with internal `BEGIN...END`)
- PostgreSQL bodyless triggers
- a regression guard for mssql `BEGIN...END` function bodies

All existing tests continue to pass.