### PR TITLE
Select into statement

### DIFF
--- a/src/defines.ts
+++ b/src/defines.ts
@@ -15,6 +15,7 @@ export type StatementType =
   | 'UPDATE'
   | 'DELETE'
   | 'SELECT'
+  | 'SELECT_INTO'
   | 'TRUNCATE'
   | 'CREATE_DATABASE'
   | 'CREATE_SCHEMA'

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1202,16 +1202,23 @@ function stateMachineStatementParser(
       }
 
       if (
-        statement.type === 'SELECT' && !sawFrom &&
+        statement.type === 'SELECT' &&
+        !sawFrom &&
         token.type === 'keyword' &&
         token.value.toUpperCase() === 'INTO' &&
-        ['mssql', 'psql'].includes(dialect)
+        ['mssql', 'psql'].includes(dialect) &&
+        parensDepth === 0
       ) {
         statement.type = 'SELECT_INTO';
         statement.executionType = 'MODIFICATION';
       }
 
-      if (statement.type === 'SELECT' && token.type === 'keyword' && token.value.toUpperCase() === 'FROM') {
+      if (
+        statement.type === 'SELECT' &&
+        token.type === 'keyword' &&
+        token.value.toUpperCase() === 'FROM' &&
+        parensDepth === 0
+      ) {
         sawFrom = true;
       }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1203,10 +1203,9 @@ function stateMachineStatementParser(
 
       if (
         statement.type === 'SELECT' &&
-        !sawFrom &&
         token.type === 'keyword' &&
         token.value.toUpperCase() === 'INTO' &&
-        ['mssql', 'psql'].includes(dialect) &&
+        ((['mssql', 'psql'].includes(dialect) && !sawFrom) || dialect === 'mysql') &&
         parensDepth === 0
       ) {
         statement.type = 'SELECT_INTO';

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -29,6 +29,7 @@ interface StatementParser {
  */
 export const EXECUTION_TYPES: Record<StatementType, ExecutionType> = {
   SELECT: 'LISTING',
+  SELECT_INTO: 'MODIFICATION',
   INSERT: 'MODIFICATION',
   DELETE: 'MODIFICATION',
   UPDATE: 'MODIFICATION',
@@ -1016,6 +1017,7 @@ function stateMachineStatementParser(
   let currentStepIndex = 0;
   let prevToken: Token | undefined;
   let prevNonWhitespaceToken: Token | undefined;
+  let sawFrom = false;
 
   let lastBlockOpener: Token | undefined;
   let anonBlockStarted = false;
@@ -1197,6 +1199,20 @@ function stateMachineStatementParser(
         parensDepth === 0
       ) {
         statement.offset = true;
+      }
+
+      if (
+        statement.type === 'SELECT' && !sawFrom &&
+        token.type === 'keyword' &&
+        token.value.toUpperCase() === 'INTO' &&
+        ['mssql', 'psql'].includes(dialect)
+      ) {
+        statement.type = 'SELECT_INTO';
+        statement.executionType = 'MODIFICATION';
+      }
+
+      if (statement.type === 'SELECT' && token.type === 'keyword' && token.value.toUpperCase() === 'FROM') {
+        sawFrom = true;
       }
 
       if (statement.type && statement.start >= 0) {

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -108,6 +108,7 @@ const SNOWFLAKE_KEYWORDS = [
   'STREAMS',
   'TASKS',
   'PIPES',
+  'INTO',
 ];
 
 const INDIVIDUALS: Record<string, Token['type']> = {

--- a/test/identifier/single-statement.spec.ts
+++ b/test/identifier/single-statement.spec.ts
@@ -1816,4 +1816,36 @@ describe('identifier', () => {
       });
     });
   });
+
+  describe('SELECT INTO detection', () => {
+    it('should identify SELECT INTO as SELECT_INTO for mssql', () => {
+      const [result] = identify('SELECT * INTO NewTable FROM SourceTable', {
+        dialect: 'mssql',
+      });
+      expect(result.type).to.equal('SELECT_INTO');
+      expect(result.executionType).to.equal('MODIFICATION');
+    });
+
+    it('should identify SELECT INTO as SELECT_INTO for psql', () => {
+      const [result] = identify('SELECT * INTO new_table FROM source_table', {
+        dialect: 'psql',
+      });
+      expect(result.type).to.equal('SELECT_INTO');
+      expect(result.executionType).to.equal('MODIFICATION');
+    });
+
+    it('should NOT identify SELECT INTO for mysql (dialect without SELECT INTO TABLE syntax)', () => {
+      const [result] = identify('SELECT * INTO new_table FROM source_table', {
+        dialect: 'mysql',
+      });
+      expect(result.type).to.equal('SELECT');
+    });
+
+    it('should NOT treat INTO after FROM as SELECT_INTO (e.g. INSERT INTO target inside a CTE column)', () => {
+      const [result] = identify('SELECT col FROM t INTO OUTFILE "x"', {
+        dialect: 'mssql',
+      });
+      expect(result.type).to.equal('SELECT');
+    });
+  });
 });

--- a/test/identifier/single-statement.spec.ts
+++ b/test/identifier/single-statement.spec.ts
@@ -1834,23 +1834,65 @@ describe('identifier', () => {
       expect(result.executionType).to.equal('MODIFICATION');
     });
 
-    it('should NOT identify SELECT INTO for mysql (dialect without SELECT INTO TABLE syntax)', () => {
-      const [result] = identify('SELECT * INTO new_table FROM source_table', {
+    it('should identify SELECT INTO OUTFILE after FROM as SELECT_INTO for mysql', () => {
+      const [result] = identify("SELECT a, b FROM t INTO OUTFILE '/tmp/out'", {
         dialect: 'mysql',
       });
-      expect(result.type).to.equal('SELECT');
+      expect(result.type).to.equal('SELECT_INTO');
+      expect(result.executionType).to.equal('MODIFICATION');
     });
 
-    it('should NOT treat INTO after FROM as SELECT_INTO (e.g. INSERT INTO target inside a CTE column)', () => {
+    it('should identify SELECT INTO OUTFILE before FROM as SELECT_INTO for mysql', () => {
+      const [result] = identify("SELECT a, b INTO OUTFILE '/tmp/out' FROM t", {
+        dialect: 'mysql',
+      });
+      expect(result.type).to.equal('SELECT_INTO');
+    });
+
+    it('should identify SELECT INTO DUMPFILE as SELECT_INTO for mysql', () => {
+      const [result] = identify("SELECT a FROM t INTO DUMPFILE '/tmp/out'", {
+        dialect: 'mysql',
+      });
+      expect(result.type).to.equal('SELECT_INTO');
+    });
+
+    it('should identify SELECT INTO variables (after FROM) as SELECT_INTO for mysql', () => {
+      const [result] = identify('SELECT a FROM t INTO @var', { dialect: 'mysql' });
+      expect(result.type).to.equal('SELECT_INTO');
+    });
+
+    it('should identify SELECT INTO variables (before FROM) as SELECT_INTO for mysql', () => {
+      const [result] = identify('SELECT a, b INTO @v1, @v2 FROM t', { dialect: 'mysql' });
+      expect(result.type).to.equal('SELECT_INTO');
+    });
+
+    it('should NOT treat INTO after FROM as SELECT_INTO for mssql (only INTO before FROM applies)', () => {
       const [result] = identify('SELECT col FROM t INTO OUTFILE "x"', {
         dialect: 'mssql',
       });
       expect(result.type).to.equal('SELECT');
     });
 
-    it('should NOT treat INTO inside a subquery as SELECT_INTO for the outer query', () => {
+    it('should NOT treat a bare SELECT as SELECT_INTO for mysql', () => {
+      const [result] = identify('SELECT a FROM t', { dialect: 'mysql' });
+      expect(result.type).to.equal('SELECT');
+    });
+
+    it('should NOT treat INSERT INTO as SELECT_INTO for mysql', () => {
+      const [result] = identify('INSERT INTO t (id) VALUES (1)', { dialect: 'mysql' });
+      expect(result.type).to.equal('INSERT');
+    });
+
+    it('should NOT treat INTO inside a subquery as SELECT_INTO for the outer query (psql)', () => {
       const [result] = identify('SELECT (SELECT id INTO foo FROM bar) AS x FROM t', {
         dialect: 'psql',
+      });
+      expect(result.type).to.equal('SELECT');
+    });
+
+    it('should NOT treat INTO inside a subquery as SELECT_INTO for the outer query (mysql)', () => {
+      const [result] = identify('SELECT a FROM (SELECT id INTO x FROM y) AS z', {
+        dialect: 'mysql',
       });
       expect(result.type).to.equal('SELECT');
     });

--- a/test/identifier/single-statement.spec.ts
+++ b/test/identifier/single-statement.spec.ts
@@ -1847,5 +1847,12 @@ describe('identifier', () => {
       });
       expect(result.type).to.equal('SELECT');
     });
+
+    it('should NOT treat INTO inside a subquery as SELECT_INTO for the outer query', () => {
+      const [result] = identify('SELECT (SELECT id INTO foo FROM bar) AS x FROM t', {
+        dialect: 'psql',
+      });
+      expect(result.type).to.equal('SELECT');
+    });
   });
 });


### PR DESCRIPTION
Add select into as its own statement type.

Current implementation only supports `psql` and `mssql` statements like `SELECT * INTO tab2 FROM tab1`.

`mysql` has a similar statement, `SELECT * FROM tab1 INTO [outfile|var]` that I think we need to consider, but I feel like it might need to be a separate statement type? `psql`'s version of this actually creates a table, whereas `mysql` exports to a file or creates a variable so I'm not sure how we want to classify that. 