### PR TITLE
Fix publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
 
       # Ensure npm 11.5.1 or later is installed for OIDC
       - name: Update npm
-        run: npm install -g npm@11
+        run: npm install -g npm@11 # Workaround until npm 12 gets fixed
 
       - run: npm install
       - run: npm run lint

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 permissions:
   id-token: write
   contents: write
-      
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -20,8 +20,8 @@ jobs:
 
       # Ensure npm 11.5.1 or later is installed for OIDC
       - name: Update npm
-        run: npm install -g npm@latest
-        
+        run: npm install -g npm@11
+
       - run: npm install
       - run: npm run lint
 


### PR DESCRIPTION
Looks like npm broke publishing on npm 12, `sigstore` is required for trusted publishing but I guess they accidentally removed it from the bundle. Rolling back to npm 11 for publishing fixes the issue

https://github.com/npm/cli/issues/9722